### PR TITLE
Update README.md to specify change from MIT to Apache2 license

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Run `ups-rs-client --help` to see all available commands and options.
 
 ## License
 
-MIT License
+Apache2 License
 
 ## Contributing
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Changed the license text in the README.md file