### PR TITLE
feat: XML content-type support with module split

### DIFF
--- a/Insights.md
+++ b/Insights.md
@@ -1,0 +1,68 @@
+# Insights
+
+## XML Content Type Support Implementation (2026-05-05)
+
+### pydicom-xml API Discovery
+
+The handoff document described functions like `dataset_to_xml`, `dataset_from_xml`,
+`extract_boundary`, and `datasets_from_multipart_xml`. None of these exist in the actual
+library. The real API is just two functions: `to_xml(dataset) -> bytes` and
+`from_xml(bytes) -> Dataset`. Always verify library APIs against the installed package,
+not documentation written before the library was finalized.
+
+### Multipart Check Must Precede XML Check
+
+`parse_response_body` must test `"multipart/related" in content_type_header` BEFORE
+`CONTENT_TYPE_XML in content_type_header`. A multipart/related response for XML search
+results has a Content-Type like:
+
+```
+multipart/related; type="application/dicom+xml"; boundary=abc
+```
+
+This header contains `application/dicom+xml` as a substring, so the XML branch would
+match first and pass the entire multipart body to `from_xml()`, which fails. Ordering
+matters when one content-type header is a substring of another.
+
+### Late-Binding Module Import Preserves Patchability
+
+When splitting a monolithic module into `cli.py` and `ups_rs_client.py`, importing
+`UPSRSClient` directly in `cli.py` via `from ... import UPSRSClient` creates a local
+binding that test patches to `dicom_ups_rs_client.ups_rs_client.UPSRSClient` cannot
+reach. The fix is to use `import dicom_ups_rs_client.ups_rs_client as _ups_rs_module`
+and call `_ups_rs_module.UPSRSClient(...)` at call-time, so the patch on the module
+attribute is honored at runtime.
+
+### WebSocket Timing Contracts Are Implicit
+
+The `asyncio.wait_for(websocket.recv(), timeout=1.0)` pattern in the WebSocket receive
+loop is load-bearing for test behavior. Tests that mock connection errors rely on this
+specific timeout to exit cleanly. When rewriting the loop, preserving the original
+`wait_for` call preserved test timing contracts that were not explicitly documented.
+
+### Module-Level Imports vs Fixture-Local Imports for Test Type Annotations
+
+When a test fixture returns a type from another test module (e.g., `MockSession` from
+`conftest.py`), using a quoted forward reference (`"MockSession"`) with a local import
+inside the fixture body triggers UP037 (remove quotes from type annotation). The correct
+pattern is to import at module level so the name is available for the annotation without
+quotes.
+
+### Splitting a 1000+ Line File
+
+The `exceptions.py`, `enums.py`, `serialization.py`, `cli.py` split was done cleanly by:
+1. Writing new modules with the extracted code
+2. Updating `ups_rs_client.py` to import from those modules
+3. Re-exporting from `__init__.py` for backward compatibility
+4. Keeping `main()` and `_event_handler` re-exported from `ups_rs_client.py` for any
+   existing callers that import them from there
+
+The re-export wrapper approach avoids breaking existing import paths while enabling the
+split.
+
+### Search Response Returns a List, Not a Dict
+
+The `_parse_success_response` helper initially wrapped non-dict parsed JSON in
+`{"data": parsed}`. UPS-RS search workitems responses are JSON arrays. Tests expect a
+`list`, not a dict wrapper. The correct behavior is to return `parsed` directly when it
+is already a list, only wrapping genuinely unexpected types.

--- a/dicom_ups_rs_client/__init__.py
+++ b/dicom_ups_rs_client/__init__.py
@@ -1,14 +1,14 @@
 """DICOM UPS-RS Client Package."""
 
-from .ups_rs_client import (
-    InputReadinessState,
-    UPSRSClient,
+from dicom_ups_rs_client.enums import InputReadinessState, UPSState
+from dicom_ups_rs_client.exceptions import (
     UPSRSError,
     UPSRSRequestError,
     UPSRSResponseError,
     UPSRSValidationError,
-    UPSState,
 )
+from dicom_ups_rs_client.serialization import CONTENT_TYPE_JSON, CONTENT_TYPE_XML
+from dicom_ups_rs_client.ups_rs_client import UPSRSClient
 
 __all__ = [
     "UPSRSClient",
@@ -18,6 +18,8 @@ __all__ = [
     "UPSRSResponseError",
     "UPSRSRequestError",
     "UPSRSValidationError",
+    "CONTENT_TYPE_JSON",
+    "CONTENT_TYPE_XML",
 ]
 
 __version__ = "0.1.0"

--- a/dicom_ups_rs_client/cli.py
+++ b/dicom_ups_rs_client/cli.py
@@ -1,0 +1,758 @@
+"""Command-line interface for the DICOM UPS-RS client."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import signal
+import sys
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pydicom import dcmread
+from pydicom.uid import generate_uid
+
+import dicom_ups_rs_client.ups_rs_client as _ups_rs_module
+from dicom_ups_rs_client.serialization import CONTENT_TYPE_JSON, CONTENT_TYPE_XML
+
+# UPSRSClient is used only in type annotations here; at runtime the client is
+# created via ``_ups_rs_module.UPSRSClient(...)`` so that test patches targeting
+# ``dicom_ups_rs_client.ups_rs_client.UPSRSClient`` take effect.
+if TYPE_CHECKING:
+    from dicom_ups_rs_client.ups_rs_client import UPSRSClient
+
+
+def _event_handler(event_data: dict[str, Any]) -> None:
+    """
+    Handle incoming UPS-RS events.
+
+    Args:
+        event_data: dictionary containing event information
+
+    """
+    try:
+        event_type_id = event_data.get("00001002", {}).get("Value", ["unknown"])[0]
+        affected_sop_instance_uid = event_data.get("00001000", {}).get("Value", ["unknown"])[0]
+        print(f"\nEVENT RECEIVED: {event_type_id} - Workitem: {affected_sop_instance_uid}")
+    except (KeyError, IndexError):
+        print("\nEVENT RECEIVED: (unable to extract event type or workitem UID)")
+
+    print(json.dumps(event_data, indent=2))
+    print("-" * 60)
+
+
+def main() -> None:
+    """Execute Main CLI entry point for UPS-RS client."""
+    parser = argparse.ArgumentParser(description="DICOM UPS-RS Client")
+    parser.add_argument(
+        "--server",
+        type=str,
+        required=True,
+        help="URL of the UPS-RS server (e.g., http://localhost:5000)",
+    )
+    parser.add_argument(
+        "--aetitle",
+        type=str,
+        help="Application Entity Title for subscription operations",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
+    parser.add_argument("--timeout", type=int, default=30, help="Request timeout in seconds")
+    parser.add_argument("--max-retries", type=int, default=3, help="Maximum number of request retries")
+
+    # Add SSL/TLS related arguments
+    parser.add_argument(
+        "--no-verify-ssl",
+        action="store_true",
+        help="Disable SSL certificate verification (not recommended)",
+    )
+    parser.add_argument(
+        "--ca-bundle",
+        type=str,
+        help="Path to CA bundle file for SSL verification",
+    )
+    parser.add_argument(
+        "--client-cert",
+        type=str,
+        help="Path to client certificate file (.pem with both cert and key)",
+    )
+    parser.add_argument(
+        "--client-cert-key",
+        type=str,
+        help="Path to separate client key file (use with --client-cert for separate files)",
+    )
+    parser.add_argument(
+        "--websocket-url-override",
+        type=str,
+        help="Override WebSocket URL template. Use {aetitle} as placeholder. Example: wss://example.com:9443/ws/subscribers/{aetitle}",
+    )
+    parser.add_argument(
+        "--content-type",
+        choices=[CONTENT_TYPE_JSON, CONTENT_TYPE_XML],
+        default=CONTENT_TYPE_JSON,
+        help="MIME type for request/response content negotiation",
+    )
+
+    # Create subparsers for different commands
+    subparsers = parser.add_subparsers(dest="command", help="Command to execute")
+
+    # Create workitem command
+    create_parser = subparsers.add_parser("create", help="Create a new workitem")
+    create_parser.add_argument("--workitem-uid", type=str, help="Optional UID for the workitem")
+    create_parser.add_argument("--input-file", type=str, help="JSON file containing workitem data")
+    create_parser.add_argument("--input-dcm", type=str, help="DICOM file containing workitem data")
+
+    # Retrieve workitem command
+    retrieve_parser = subparsers.add_parser("retrieve", help="Retrieve a workitem")
+    retrieve_parser.add_argument(
+        "--workitem-uid",
+        type=str,
+        required=True,
+        help="UID of the workitem to retrieve",
+    )
+    retrieve_parser.add_argument(
+        "--output-file",
+        type=str,
+        help="Output file to save the retrieved workitem JSON",
+    )
+
+    # Search workitems command
+    search_parser = subparsers.add_parser("search", help="Search for workitems")
+    search_parser.add_argument(
+        "--match",
+        action="append",
+        help="Match parameters (e.g., '00741000=SCHEDULED')",
+        default=[],
+    )
+    search_parser.add_argument(
+        "--includefield",
+        action="append",
+        help="Fields to include in results",
+        default=[],
+    )
+    search_parser.add_argument("--fuzzy", action="store_true", help="Enable fuzzy matching")
+    search_parser.add_argument(
+        "--state",
+        choices=["SCHEDULED", "IN PROGRESS", "CANCELED", "COMPLETED"],
+        help="Filter by Procedure Step State (00741000)",
+    )
+    search_parser.add_argument(
+        "--readiness",
+        choices=["READY", "UNAVAILABLE", "INCOMPLETE"],
+        help="Filter by Input Readiness State (00404041)",
+    )
+    search_parser.add_argument(
+        "--start-date",
+        type=str,
+        help="Filter by Scheduled Start Date (00404005) in YYYYMMDD format",
+    )
+    search_parser.add_argument("--label", type=str, help="Filter by Procedure Step Label (00741204)")
+    search_parser.add_argument("--offset", type=int, default=0, help="Starting position of results")
+    search_parser.add_argument("--limit", type=int, help="Maximum number of results to return")
+    search_parser.add_argument("--no-cache", action="store_true", help="Request non-cached results")
+    search_parser.add_argument("--output-file", type=str, help="Output file to save search results")
+    search_parser.add_argument("--summary", action="store_true", help="Display only a summary of results")
+    search_parser.add_argument(
+        "--display-fields",
+        type=str,
+        help="Comma-separated list of fields to display in output summary",
+    )
+
+    # Update workitem command
+    update_parser = subparsers.add_parser("update", help="Update a workitem")
+    update_parser.add_argument("--workitem-uid", type=str, required=True, help="UID of the workitem to update")
+    update_parser.add_argument("--transaction-uid", type=str, help="Transaction UID")
+    update_parser.add_argument("--input-file", type=str, help="JSON file containing update data")
+    update_parser.add_argument("--procedure-label", type=str, help="Set the Procedure Step Label (0074,1204)")
+    update_parser.add_argument(
+        "--procedure-description",
+        type=str,
+        help="Set the Procedure Step Description (0040,0007)",
+    )
+
+    # Change workitem state command
+    state_parser = subparsers.add_parser("change-state", help="Change workitem state")
+    state_parser.add_argument(
+        "--workitem-uid",
+        type=str,
+        required=True,
+        help="UID of the workitem to change state",
+    )
+    state_parser.add_argument(
+        "--state",
+        type=str,
+        required=True,
+        choices=["IN PROGRESS", "COMPLETED", "CANCELED"],
+        help="New state for the workitem",
+    )
+    state_parser.add_argument(
+        "--transaction-uid",
+        type=str,
+        help="Transaction UID (required for COMPLETED/CANCELED states, optional for IN PROGRESS)",
+    )
+
+    # Request cancellation command
+    cancel_parser = subparsers.add_parser("request-cancel", help="Request cancellation of a workitem")
+    cancel_parser.add_argument(
+        "--workitem-uid",
+        type=str,
+        required=True,
+        help="UID of the workitem to request cancellation for",
+    )
+    cancel_parser.add_argument("--reason", type=str, help="Reason for the cancellation request")
+    cancel_parser.add_argument("--contact-name", type=str, help="Display name of the contact person")
+    cancel_parser.add_argument(
+        "--contact-uri",
+        type=str,
+        help="URI for contacting the requestor (e.g., mailto:user@example.com)",
+    )
+
+    # Subscribe command
+    subscribe_parser = subparsers.add_parser("subscribe", help="Subscribe to workitem events")
+    subscribe_group = subscribe_parser.add_mutually_exclusive_group(required=True)
+    subscribe_group.add_argument("--worklist", action="store_true", help="Subscribe to the entire worklist")
+    subscribe_group.add_argument(
+        "--filtered-worklist",
+        action="store_true",
+        help="Subscribe to a filtered worklist",
+    )
+    subscribe_group.add_argument("--workitem", type=str, help="UID of a specific workitem to subscribe to")
+    subscribe_parser.add_argument(
+        "--filter",
+        action="append",
+        help="Filter parameters for filtered worklist (e.g., '00741000=SCHEDULED')",
+        default=[],
+    )
+    subscribe_parser.add_argument(
+        "--deletion-lock",
+        action="store_true",
+        help="Request deletion lock for the subscription",
+    )
+    subscribe_parser.add_argument(
+        "--monitor",
+        action="store_true",
+        help="Monitor for event notifications after subscribing",
+    )
+
+    # Unsubscribe command
+    unsubscribe_parser = subparsers.add_parser("unsubscribe", help="Unsubscribe from workitem events")
+    unsubscribe_group = unsubscribe_parser.add_mutually_exclusive_group(required=True)
+    unsubscribe_group.add_argument("--worklist", action="store_true", help="Unsubscribe from the entire worklist")
+    unsubscribe_group.add_argument(
+        "--filtered-worklist",
+        action="store_true",
+        help="Unsubscribe from a filtered worklist",
+    )
+    unsubscribe_group.add_argument("--workitem", type=str, help="UID of a specific workitem to unsubscribe from")
+    unsubscribe_parser.add_argument(
+        "--filter",
+        action="append",
+        help="Filter parameters for filtered worklist (e.g., '00741000=SCHEDULED')",
+        default=[],
+    )
+    unsubscribe_parser.add_argument(
+        "--deletion-lock",
+        action="store_true",
+        help="Request deletion lock for the unsubscription",
+    )
+
+    args = parser.parse_args()
+
+    # Set up logging
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(level=log_level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+    # Check for required command
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    # Determine SSL verification setting
+    verify_ssl: bool | str = True
+    if args.no_verify_ssl:
+        verify_ssl = False
+    elif args.ca_bundle:
+        verify_ssl = args.ca_bundle
+
+    # Validate client certificate arguments
+    if args.client_cert_key and not args.client_cert:
+        parser.error("--client-cert-key requires --client-cert to also be specified")
+
+    # Determine client certificate setting
+    client_cert: str | tuple[str, str] | None = None
+    if args.client_cert:
+        if args.client_cert_key:
+            client_cert = (args.client_cert, args.client_cert_key)
+        else:
+            client_cert = args.client_cert
+
+    # Initialize client with SSL settings.
+    # Access UPSRSClient through the module reference so that tests can patch
+    # ``dicom_ups_rs_client.ups_rs_client.UPSRSClient`` and have it take effect.
+    client = _ups_rs_module.UPSRSClient(
+        base_url=args.server,
+        aetitle=args.aetitle,
+        timeout=args.timeout,
+        max_retries=args.max_retries,
+        verify_ssl=verify_ssl,
+        client_cert=client_cert,
+        websocket_url_override=args.websocket_url_override,
+        content_type=args.content_type,
+    )
+
+    try:
+        # Execute the requested command
+        if args.command == "create":
+            _handle_create_command(client, args)
+        elif args.command == "retrieve":
+            _handle_retrieve_command(client, args)
+        elif args.command == "search":
+            _handle_search_command(client, args)
+        elif args.command == "update":
+            _handle_update_command(client, args)
+        elif args.command == "change-state":
+            _handle_change_state_command(client, args)
+        elif args.command == "request-cancel":
+            _handle_cancel_request_command(client, args)
+        elif args.command == "subscribe":
+            _handle_subscribe_command(client, args)
+        elif args.command == "unsubscribe":
+            _handle_unsubscribe_command(client, args)
+    finally:
+        # Ensure proper cleanup
+        client.close()
+
+
+def _handle_create_command(client: UPSRSClient, args: argparse.Namespace) -> None:
+    """Handle the create workitem command."""
+    # Generate a DICOM UID if one wasn't provided on the command line
+    workitem_uid = args.workitem_uid or str(generate_uid())
+
+    # Load workitem data if provided
+    workitem_data = None
+    if args.input_file:
+        try:
+            input_path = Path(args.input_file)
+            with input_path.open() as f:
+                workitem_data = json.load(f)
+        except Exception as e:
+            logging.error(f"Failed to load workitem data from {args.input_file}: {str(e)}")
+            sys.exit(1)
+
+    if args.input_dcm:
+        try:
+            dcm_path = Path(args.input_dcm)
+            local_json_path = Path(dcm_path.name.removesuffix("dcm") + "json")
+
+            workitem_ds = dcmread(args.input_dcm)
+            # Make sure the workitem_uid is consistent in the post and the data
+            if not args.workitem_uid:
+                workitem_uid = str(workitem_ds.SOPInstanceUID)
+            else:
+                workitem_ds.SOPInstanceUID = workitem_uid
+            workitem_uid = workitem_uid or str(generate_uid())
+
+            workitem_data = json.loads(workitem_ds.to_json())
+            local_json_path.write_text(json.dumps(workitem_data, indent=2))
+
+        except Exception as e:
+            logging.error(f"Failed to load workitem data from {args.input_dcm}: {str(e)}")
+            sys.exit(1)
+
+    # Create workitem
+    success, response = client.create_workitem(workitem_data, workitem_uid)
+
+    if success:
+        print("Workitem created successfully")
+        print(json.dumps(response, indent=2, default=str))
+        print(f"Workitem UID: {workitem_uid}")
+        sys.exit(0)
+    else:
+        print(f"Failed to create workitem: {response}")
+        sys.exit(1)
+
+
+def _handle_retrieve_command(client: UPSRSClient, args: argparse.Namespace) -> None:
+    """Handle the retrieve workitem command."""
+    success, response = client.retrieve_workitem(args.workitem_uid)
+
+    if success:
+        print("Workitem retrieved successfully")
+        formatted_response = json.dumps(response, indent=2, default=str)
+        print(formatted_response)
+
+        # Save to file if requested
+        if args.output_file:
+            try:
+                output_path = Path(args.output_file)
+                with output_path.open("w") as f:
+                    f.write(formatted_response)
+                print(f"Workitem saved to {args.output_file}")
+            except Exception as e:
+                print(f"Failed to save workitem to file: {str(e)}")
+                sys.exit(1)
+
+        sys.exit(0)
+    else:
+        print(f"Failed to retrieve workitem: {response}")
+        sys.exit(1)
+
+
+def _handle_search_command(client: UPSRSClient, args: argparse.Namespace) -> None:
+    """Handle the search workitems command."""
+    # Parse match parameters
+    match_parameters: dict[str, str] = {}
+    for param in args.match:
+        if "=" in param:
+            key, value = param.split("=", 1)
+            match_parameters[key] = value
+        else:
+            logging.warning(f"Ignoring invalid match parameter (missing '='): {param}")
+
+    # Add common search parameters if provided
+    if args.state:
+        match_parameters["00741000"] = args.state
+
+    if args.readiness:
+        match_parameters["00404041"] = args.readiness
+
+    if args.start_date:
+        match_parameters["00404005"] = args.start_date
+
+    if args.label:
+        match_parameters["00741204"] = args.label
+
+    # Inform user about search criteria
+    _summarize_search_criteria(match_parameters)
+
+    # Perform search
+    success, response = client.search_workitems(
+        match_parameters,
+        args.includefield,
+        args.fuzzy,
+        args.offset,
+        args.limit,
+        args.no_cache,
+    )
+
+    if not success:
+        print(f"Failed to search workitems: {response}")
+        sys.exit(1)
+
+    if isinstance(response, list) and response:
+        result_count = len(response)
+        print(f"Search returned {result_count} result(s)")
+
+        # Display summary if requested or full results
+        if args.summary:
+            _summarize_search_results(args, response)
+        else:
+            # Print full formatted results
+            formatted_response = json.dumps(response, indent=2, default=str)
+            print(formatted_response)
+
+        # Save to file if requested
+        if args.output_file:
+            try:
+                output_path = Path(args.output_file)
+                with output_path.open("w") as f:
+                    f.write(json.dumps(response, indent=2, default=str))
+                print(f"Search results saved to {args.output_file}")
+            except Exception as e:
+                print(f"Failed to save search results to file: {str(e)}")
+                sys.exit(1)
+    else:
+        print("No matching workitems found")
+
+    sys.exit(0)
+
+
+def _summarize_search_criteria(match_parameters: dict[str, str]) -> None:
+    """Print a summary of the search criteria."""
+    if match_parameters:
+        print("Searching with criteria:")
+        for tag, value in match_parameters.items():
+            tag_name = ""
+            if tag == "00741000":
+                tag_name = "Procedure Step State"
+            elif tag == "00404041":
+                tag_name = "Input Readiness State"
+            elif tag == "00404005":
+                tag_name = "Scheduled Start Date"
+            elif tag == "00741204":
+                tag_name = "Procedure Step Label"
+
+            if tag_name:
+                print(f"  {tag_name} ({tag}) = {value}")
+            else:
+                print(f"  {tag} = {value}")
+    else:
+        print("Searching with no criteria (will return all workitems)")
+
+
+def _summarize_search_results(args: argparse.Namespace, response: list[Any]) -> None:
+    """Print a summary of the search results."""
+    print("\nSummary of Workitems:")
+    print("-" * 80)
+
+    # Determine which fields to display in summary
+    display_fields = (
+        args.display_fields.split(",") if args.display_fields else ["00080018", "00741000", "00404041", "00741204"]
+    )
+    # Print header
+    header_row = []
+    for field in display_fields:
+        if field == "00080018":
+            header_row.append("SOP Instance UID")
+        elif field == "00404005":
+            header_row.append("Scheduled Start")
+        elif field == "00404041":
+            header_row.append("Input Readiness")
+        elif field == "00741000":
+            header_row.append("Procedure Step State")
+        elif field == "00741204":
+            header_row.append("Procedure Label")
+        else:
+            header_row.append(field)
+
+    print(" | ".join(header_row))
+    print("-" * 80)
+
+    # Print each workitem
+    for wi in response:
+        row = []
+        for field in display_fields:
+            if isinstance(wi, dict) and field in wi and "Value" in wi[field] and wi[field]["Value"]:
+                value = wi[field]["Value"][0]
+                # Truncate long values
+                if isinstance(value, str) and len(value) > 30:
+                    value = f"{value[:27]}..."
+                row.append(str(value))
+            else:
+                row.append("N/A")
+
+        print(" | ".join(row))
+
+    print("-" * 80)
+
+
+def _handle_update_command(client: UPSRSClient, args: argparse.Namespace) -> None:
+    """Handle the update workitem command."""
+    # Prepare update data
+    update_data: dict[str, Any] = {}
+
+    # Load from file if provided
+    if args.input_file:
+        try:
+            input_path = Path(args.input_file)
+            with input_path.open() as f:
+                update_data = json.load(f)
+        except Exception as e:
+            logging.error(f"Failed to load update data from {args.input_file}: {str(e)}")
+            sys.exit(1)
+
+    # Add command line attributes if provided
+    if args.procedure_label:
+        update_data["00741204"] = {"vr": "LO", "Value": [args.procedure_label]}
+
+    if args.procedure_description:
+        update_data["00400007"] = {"vr": "LO", "Value": [args.procedure_description]}
+
+    if not args.transaction_uid:
+        print("Transaction UID not provided, only valid if UPS is SCHEDULED")
+
+    # Ensure we have some update data
+    if not update_data:
+        logging.error("No update data provided. Use --input-file or command line options.")
+        sys.exit(1)
+
+    # Update workitem
+    success, response = client.update_workitem(args.workitem_uid, args.transaction_uid, update_data)
+
+    if success:
+        print("Workitem updated successfully")
+
+        # Display any warnings
+        if isinstance(response, dict) and "warning" in response:
+            print(f"Warning: {response['warning']}")
+
+        # Display full response if available and verbose
+        if args.verbose and isinstance(response, dict) and "response" in response:
+            print("\nFull response:")
+            print(json.dumps(response["response"], indent=2, default=str))
+
+        sys.exit(0)
+    else:
+        print(f"Failed to update workitem: {response}")
+        sys.exit(1)
+
+
+def _handle_change_state_command(client: UPSRSClient, args: argparse.Namespace) -> None:
+    """Handle the change workitem state command."""
+    # Change workitem state
+    success, response = client.change_workitem_state(args.workitem_uid, args.state, args.transaction_uid)
+
+    if success:
+        print(f"Workitem state changed successfully to {args.state}")
+
+        # Display transaction UID for future reference
+        if isinstance(response, dict) and "transaction_uid" in response:
+            print(f"Transaction UID: {response['transaction_uid']}")
+            print("Keep this UID for future state changes to this workitem")
+
+        # Display any warnings
+        if isinstance(response, dict) and "warning" in response:
+            print(f"Warning: {response['warning']}")
+
+        # Display full response if verbose
+        if args.verbose and isinstance(response, dict) and "response" in response:
+            print("\nFull response:")
+            print(json.dumps(response["response"], indent=2, default=str))
+
+        sys.exit(0)
+    else:
+        print(f"Failed to change workitem state: {response}")
+        sys.exit(1)
+
+
+def _handle_cancel_request_command(client: UPSRSClient, args: argparse.Namespace) -> None:
+    """Handle the request cancellation command."""
+    # Request cancellation
+    success, response = client.request_cancellation(args.workitem_uid, args.reason, args.contact_name, args.contact_uri)
+
+    if not success:
+        print(f"Failed to request cancellation: {response}")
+        sys.exit(1)
+
+    print("Cancellation request sent successfully")
+
+    # Display any warnings
+    if isinstance(response, dict) and "warning" in response:
+        print(f"Warning: {response['warning']}")
+
+    # Display full response if available and verbose
+    if args.verbose and isinstance(response, dict) and "response" in response:
+        print("\nFull response:")
+        print(json.dumps(response["response"], indent=2, default=str))
+
+    # Include note about processing
+    print("\nNote: The cancellation request has been accepted by the server, but the workitem")
+    print("owner is not obliged to honor the request and may not receive notification.")
+
+    sys.exit(0)
+
+
+def _handle_subscribe_command(client: UPSRSClient, args: argparse.Namespace) -> None:
+    """Handle the subscribe command."""
+    # Check if AE Title is provided
+    if not args.aetitle:
+        print("Error: AE Title (--aetitle) is required for subscription operations")
+        sys.exit(1)
+
+    # Handle different subscription types
+    if args.worklist:
+        success, response = client.subscribe_to_worklist(args.deletion_lock)
+        subscription_type = "worklist"
+    elif args.filtered_worklist:
+        # Parse filter parameters
+        filter_params: dict[str, str] = {}
+        for param in args.filter:
+            if "=" in param:
+                key, value = param.split("=", 1)
+                filter_params[key] = value
+            else:
+                logging.warning(f"Ignoring invalid filter parameter (missing '='): {param}")
+
+        if not filter_params:
+            logging.error("Filtered worklist subscription requires at least one filter parameter")
+            sys.exit(1)
+
+        success, response = client.subscribe_to_filtered_worklist(filter_params, args.deletion_lock)
+        subscription_type = "filtered worklist"
+    else:  # workitem
+        success, response = client.subscribe_to_workitem(args.workitem, args.deletion_lock)
+        subscription_type = f"workitem {args.workitem}"
+
+    if success:
+        print(f"Successfully subscribed to {subscription_type}")
+
+        # Display WebSocket URL if available
+        if isinstance(response, dict) and "ws_url" in response:
+            print(f"WebSocket URL: {response['ws_url']}")
+
+        # Display any warnings
+        if isinstance(response, dict) and "warning" in response:
+            print(f"Warning: {response['warning']}")
+
+        # Start monitoring if requested
+        if args.monitor:
+            print("\nStarting event monitoring. Press Ctrl+C to stop.")
+
+            # Set up signal handler for graceful shutdown
+            def signal_handler(sig: int, frame: object) -> None:  # noqa: ARG001
+                print("\nShutting down...")
+                client.disconnect()
+                sys.exit(0)
+
+            signal.signal(signal.SIGINT, signal_handler)
+
+            # Connect to WebSocket and start receiving events
+            # assign a callback to perform application specific processing
+            client.connect_websocket(event_callback=_event_handler)
+
+            # Keep the main thread alive
+            try:
+                while True:
+                    time.sleep(1)
+            except KeyboardInterrupt:
+                client.disconnect()
+
+        sys.exit(0)
+    else:
+        print(f"Failed to subscribe to {subscription_type}: {response}")
+        sys.exit(1)
+
+
+def _handle_unsubscribe_command(client: UPSRSClient, args: argparse.Namespace) -> None:
+    """Handle the unsubscribe command."""
+    # Check if AE Title is provided
+    if not args.aetitle:
+        print("Error: AE Title (--aetitle) is required for subscription operations")
+        sys.exit(1)
+
+    # Handle different subscription types
+    if args.worklist:
+        success, response = client.unsubscribe_from_worklist(args.deletion_lock)
+        subscription_type = "worklist"
+    elif args.filtered_worklist:
+        # Parse filter parameters
+        filter_params = {}
+        for param in args.filter:
+            if "=" in param:
+                key, value = param.split("=", 1)
+                filter_params[key] = value
+            else:
+                logging.warning(f"Ignoring invalid filter parameter (missing '='): {param}")
+
+        if not filter_params:
+            logging.error("Filtered worklist subscription requires at least one filter parameter")
+            sys.exit(1)
+
+        success, response = client.unsubscribe_from_filtered_worklist(filter_params, args.deletion_lock)
+        subscription_type = "filtered worklist"
+    else:  # workitem
+        success, response = client.unsubscribe_from_workitem(args.workitem, args.deletion_lock)
+        subscription_type = f"workitem {args.workitem}"
+
+    if success:
+        print(f"Successfully unsubscribed from {subscription_type}")
+
+        # Display any warnings
+        if isinstance(response, dict) and "warning" in response:
+            print(f"Warning: {response['warning']}")
+
+        sys.exit(0)
+    else:
+        print(f"Failed to unsubscribe from {subscription_type}: {response}")
+        sys.exit(1)

--- a/dicom_ups_rs_client/enums.py
+++ b/dicom_ups_rs_client/enums.py
@@ -1,0 +1,28 @@
+"""Enumerations for the DICOM UPS-RS client."""
+
+from enum import Enum, auto
+
+
+class UPSState(Enum):
+    """UPS Procedure Step States as defined in DICOM."""
+
+    SCHEDULED = auto()
+    IN_PROGRESS = auto()
+    CANCELED = auto()
+    COMPLETED = auto()
+
+    def __str__(self) -> str:
+        """Return string representation for UPS-RS protocol."""
+        return self.name.replace("_", " ")
+
+
+class InputReadinessState(Enum):
+    """UPS Input Readiness States as defined in DICOM."""
+
+    READY = auto()
+    UNAVAILABLE = auto()
+    INCOMPLETE = auto()
+
+    def __str__(self) -> str:
+        """Return string representation for UPS-RS protocol."""
+        return self.name

--- a/dicom_ups_rs_client/exceptions.py
+++ b/dicom_ups_rs_client/exceptions.py
@@ -1,0 +1,37 @@
+"""Custom exceptions for the DICOM UPS-RS client."""
+
+
+class UPSRSError(Exception):
+    """Base exception class for UPS-RS client errors."""
+
+    pass
+
+
+class UPSRSResponseError(UPSRSError):
+    """Exception raised for errors in the response from the UPS-RS server."""
+
+    def __init__(self, message: str, status_code: int, response_text: str | None = None) -> None:
+        """
+        Initialize the exception.
+
+        Args:
+            message: Human-readable error message.
+            status_code: HTTP status code received from the server.
+            response_text: Optional raw response body for debugging.
+
+        """
+        self.status_code = status_code
+        self.response_text = response_text
+        super().__init__(message)
+
+
+class UPSRSRequestError(UPSRSError):
+    """Exception raised for errors in making requests to the UPS-RS server."""
+
+    pass
+
+
+class UPSRSValidationError(UPSRSError):
+    """Exception raised for validation errors in client inputs."""
+
+    pass

--- a/dicom_ups_rs_client/serialization.py
+++ b/dicom_ups_rs_client/serialization.py
@@ -51,7 +51,10 @@ def make_headers(content_type: str, extra: dict[str, str] | None = None) -> dict
         "Accept": content_type,
     }
     if extra:
-        headers.update(extra)
+        # Filter out Content-Type and Accept to prevent accidental override
+        protected = {"content-type", "accept"}
+        filtered = {k: v for k, v in extra.items() if k.lower() not in protected}
+        headers.update(filtered)
     return headers
 
 

--- a/dicom_ups_rs_client/serialization.py
+++ b/dicom_ups_rs_client/serialization.py
@@ -1,0 +1,207 @@
+"""
+Content-type negotiation, serialization, and response parsing for UPS-RS.
+
+This module handles:
+- Building HTTP headers for DICOM content-type negotiation.
+- Serializing request bodies for both application/dicom+json and application/dicom+xml.
+- Parsing success and error responses, dispatching on Content-Type.
+
+WebSocket messages are always application/dicom+json per PS3.18 Section 8.10.5
+and are NOT handled here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from pydicom import Dataset
+
+logger = logging.getLogger(__name__)
+
+CONTENT_TYPE_JSON = "application/dicom+json"
+CONTENT_TYPE_XML = "application/dicom+xml"
+
+if TYPE_CHECKING:
+    pass
+
+
+def make_headers(content_type: str, extra: dict[str, str] | None = None) -> dict[str, str]:
+    """
+    Build HTTP headers for a UPS-RS request.
+
+    The Content-Type and Accept headers are set to the negotiated content type.
+    Additional headers can be merged via the ``extra`` parameter.
+
+    Args:
+        content_type: MIME type to use for Content-Type and Accept
+            (``application/dicom+json`` or ``application/dicom+xml``).
+        extra: Optional mapping of additional headers to merge into the result.
+            Keys in ``extra`` override the defaults only when they do not duplicate
+            Content-Type or Accept (those are always set from ``content_type``).
+
+    Returns:
+        A new dict containing at minimum ``Content-Type`` and ``Accept`` headers.
+
+    """
+    headers: dict[str, str] = {
+        "Content-Type": content_type,
+        "Accept": content_type,
+    }
+    if extra:
+        headers.update(extra)
+    return headers
+
+
+def serialize_request(data: dict[str, Any] | Dataset, content_type: str) -> bytes:
+    """
+    Serialize a request body according to the negotiated content type.
+
+    For ``application/dicom+xml``, the data is converted to a pydicom
+    ``Dataset`` (if it is not already one) and then serialised via
+    ``pydicom_xml.to_xml()``.  For all other content types (including the
+    default ``application/dicom+json``), the data is serialised as JSON.
+
+    Args:
+        data: Request body as a JSON-compatible dict or a pydicom ``Dataset``.
+        content_type: MIME type controlling the serialisation path.
+
+    Returns:
+        UTF-8–encoded bytes ready to be sent as an HTTP request body.
+
+    Raises:
+        ValueError: If ``data`` cannot be converted to a Dataset for XML
+            serialisation.
+
+    """
+    if content_type == CONTENT_TYPE_XML:
+        from pydicom_xml import to_xml
+
+        if isinstance(data, Dataset):
+            ds = data
+        else:
+            ds = Dataset.from_json(json.dumps(data))
+        return to_xml(ds)
+
+    # Default: JSON
+    return json.dumps(data).encode("utf-8")
+
+
+def extract_boundary(content_type_header: str) -> str | None:
+    """
+    Extract the multipart boundary string from a Content-Type header value.
+
+    Args:
+        content_type_header: The full value of the Content-Type HTTP header,
+            e.g. ``multipart/related; type="application/dicom+xml"; boundary=xyz``.
+
+    Returns:
+        The boundary string without surrounding quotes, or ``None`` when the
+        header does not contain a boundary parameter.
+
+    """
+    match = re.search(r'boundary="?([^";]+)"?', content_type_header, re.IGNORECASE)
+    return match.group(1) if match else None
+
+
+def parse_response_body(
+    content: bytes,
+    text: str,
+    content_type_header: str,
+) -> Any:  # noqa: ANN401  – mirrors response.json() return type
+    """
+    Parse an HTTP response body based on Content-Type.
+
+    Decision logic:
+
+    1. If the Content-Type contains ``application/dicom+xml`` → parse as a
+       single DICOM XML document via ``pydicom_xml.from_xml()``.
+    2. If the Content-Type contains ``multipart/related`` → extract the
+       boundary and parse each MIME part as DICOM XML via
+       ``pydicom_xml.from_xml()``, returning a ``list[Dataset]``.
+    3. Otherwise → call ``json.loads(text)`` (the historic behaviour).
+
+    Args:
+        content: Raw response body bytes.
+        text: Response body decoded as a string (used for JSON fallback).
+        content_type_header: Value of the HTTP ``Content-Type`` response header.
+
+    Returns:
+        A ``Dataset``, a ``list[Dataset]``, or the result of ``json.loads(text)``
+        depending on the content type.
+
+    Raises:
+        json.JSONDecodeError: If the JSON fallback path is taken but the body
+            is not valid JSON.
+
+    """
+    # Check multipart BEFORE checking for application/dicom+xml because the
+    # multipart Content-Type header also contains the type parameter value
+    # 'application/dicom+xml', which would otherwise be matched first.
+    if "multipart/related" in content_type_header:
+        boundary = extract_boundary(content_type_header)
+        return _parse_multipart_xml(content, boundary)
+
+    if CONTENT_TYPE_XML in content_type_header:
+        from pydicom_xml import from_xml
+
+        return from_xml(content)
+
+    # Default JSON path
+    return json.loads(text)
+
+
+def _parse_multipart_xml(content: bytes, boundary: str | None) -> list[Dataset]:
+    """
+    Parse a multipart/related body whose parts are DICOM XML documents.
+
+    This handles the search response format where a server returns multiple
+    NativeDicomModel documents wrapped in a MIME multipart envelope.
+
+    Args:
+        content: Full multipart body bytes.
+        boundary: Multipart boundary string (without leading ``--``).
+            When ``None``, an empty list is returned.
+
+    Returns:
+        A list of ``Dataset`` objects parsed from each MIME part body.
+
+    """
+    from pydicom_xml import from_xml
+
+    if boundary is None:
+        logger.warning("multipart/related response missing boundary parameter; returning empty list")
+        return []
+
+    delimiter = f"--{boundary}".encode()
+    end_delimiter = f"--{boundary}--".encode()
+
+    datasets: list[Dataset] = []
+    parts = content.split(delimiter)
+
+    for part in parts:
+        stripped = part.strip()
+        if not stripped or stripped == b"--" or stripped == end_delimiter.lstrip(b"--"):
+            continue
+        # Each MIME part has headers followed by a blank line, then the body
+        if b"\r\n\r\n" in stripped:
+            _, part_body = stripped.split(b"\r\n\r\n", 1)
+        elif b"\n\n" in stripped:
+            _, part_body = stripped.split(b"\n\n", 1)
+        else:
+            part_body = stripped
+
+        # Remove trailing boundary marker if present
+        part_body = part_body.rstrip(b"\r\n")
+        if not part_body:
+            continue
+
+        try:
+            ds = from_xml(part_body)
+            datasets.append(ds)
+        except Exception:
+            logger.exception("Failed to parse multipart DICOM XML part; skipping")
+
+    return datasets

--- a/dicom_ups_rs_client/ups_rs_client.py
+++ b/dicom_ups_rs_client/ups_rs_client.py
@@ -1405,7 +1405,7 @@ class UPSRSClient:
                     break
 
                 retry_count += 1
-                if retry_count > max_retries:
+                if retry_count >= max_retries:
                     self.logger.error(f"Maximum retries exceeded. Last error: {e}")
                     self.running = False
                     break

--- a/dicom_ups_rs_client/ups_rs_client.py
+++ b/dicom_ups_rs_client/ups_rs_client.py
@@ -1,26 +1,29 @@
 """DICOM UPS-RS Client."""
 
-import argparse
 import asyncio
 import json
 import logging
-import signal
-import sys
 import threading
 import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
-from enum import Enum, auto
-from pathlib import Path
 from typing import Any
-
-# from asyncio import Future
 from urllib.parse import urlencode
 
 import requests
-from pydicom import Dataset, dcmread, uid
+from pydicom import Dataset, uid
 from pydicom.uid import generate_uid
+
+from dicom_ups_rs_client.enums import InputReadinessState, UPSState
+from dicom_ups_rs_client.exceptions import UPSRSError, UPSRSRequestError, UPSRSResponseError, UPSRSValidationError
+from dicom_ups_rs_client.serialization import (
+    CONTENT_TYPE_JSON,
+    CONTENT_TYPE_XML,
+    make_headers,
+    parse_response_body,
+    serialize_request,
+)
 
 __all__ = [
     "UPSRSClient",
@@ -30,68 +33,9 @@ __all__ = [
     "UPSRSResponseError",
     "UPSRSRequestError",
     "UPSRSValidationError",
+    "CONTENT_TYPE_JSON",
+    "CONTENT_TYPE_XML",
 ]
-
-
-class UPSState(Enum):
-    """UPS Procedure Step States as defined in DICOM."""
-
-    SCHEDULED = auto()
-    IN_PROGRESS = auto()
-    CANCELED = auto()
-    COMPLETED = auto()
-
-    def __str__(self) -> str:
-        """Return string representation for UPS-RS protocol."""
-        return self.name.replace("_", " ")
-
-
-class InputReadinessState(Enum):
-    """UPS Input Readiness States as defined in DICOM."""
-
-    READY = auto()
-    UNAVAILABLE = auto()
-    INCOMPLETE = auto()
-
-    def __str__(self) -> str:
-        """Return string representation for UPS-RS protocol."""
-        return self.name
-
-
-class UPSRSError(Exception):
-    """Base exception class for UPS-RS client errors."""
-
-    pass
-
-
-class UPSRSResponseError(UPSRSError):
-    """Exception raised for errors in the response from the UPS-RS server."""
-
-    def __init__(self, message: str, status_code: int, response_text: str | None = None) -> None:
-        """
-        Initialize the exception.
-
-        Args:
-            message (str): _description_
-            status_code (int): _description_
-            response_text (str | None, optional): _description_. Defaults to None.
-
-        """
-        self.status_code = status_code
-        self.response_text = response_text
-        super().__init__(message)
-
-
-class UPSRSRequestError(UPSRSError):
-    """Exception raised for errors in making requests to the UPS-RS server."""
-
-    pass
-
-
-class UPSRSValidationError(UPSRSError):
-    """Exception raised for validation errors in client inputs."""
-
-    pass
 
 
 class UPSRSClient:
@@ -114,6 +58,7 @@ class UPSRSClient:
         verify_ssl: bool | str = True,
         client_cert: str | tuple[str, str] | None = None,
         websocket_url_override: str | None = None,
+        content_type: str = CONTENT_TYPE_JSON,
     ) -> None:
         """
         Initialize the UPS-RS client.
@@ -136,6 +81,10 @@ class UPSRSClient:
             websocket_url_override: Optional override for WebSocket URL template.
                 Can include {aetitle} placeholder.
                 Example: "wss://example.com:9443/ws/subscribers/{aetitle}"
+            content_type: MIME type for request/response content negotiation.
+                Defaults to ``application/dicom+json``.
+                Use ``application/dicom+xml`` for XML content type.
+                WebSocket notifications always use JSON per PS3.18 Section 8.10.5.
 
         """
         self.base_url = base_url.rstrip("/")
@@ -145,6 +94,8 @@ class UPSRSClient:
         self.retry_delay = retry_delay
         self.verify_ssl = verify_ssl
         self.client_cert = client_cert
+        self.content_type = content_type
+
         # Validate client_cert tuple shape early
         if self.client_cert is not None:
             if not (
@@ -185,11 +136,11 @@ class UPSRSClient:
         # Thread pool for async operations
         self.executor = ThreadPoolExecutor(max_workers=5)
 
-    def __enter__(self):  # noqa: ANN204
+    def __enter__(self) -> "UPSRSClient":
         """Enter the runtime context for this client."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):  # noqa: ANN001, ANN204
+    def __exit__(self, exc_type: type | None, exc_val: Exception | None, exc_tb: object | None) -> bool:
         """Exit the runtime context for this client."""
         self.close()
         return False  # Propagate exceptions
@@ -222,6 +173,24 @@ class UPSRSClient:
                 # Log the exception
                 if hasattr(self, "logger"):
                     self.logger.error(f"Error closing session: {e}")
+
+    # ========== Header helpers ==========
+
+    def _make_headers(self, extra: dict[str, str] | None = None) -> dict[str, str]:
+        """
+        Build HTTP headers with the negotiated content type.
+
+        Args:
+            extra: Optional additional headers to merge. Keys in ``extra``
+                override the defaults only when they do not duplicate the
+                Content-Type or Accept keys (those are always derived from
+                ``self.content_type``).
+
+        Returns:
+            A dict containing at minimum ``Content-Type`` and ``Accept`` headers.
+
+        """
+        return make_headers(self.content_type, extra)
 
     # ========== Core Operations ==========
 
@@ -256,11 +225,7 @@ class UPSRSClient:
                 )
             endpoint = f"{endpoint}?workitem={workitem_uid}"
 
-        # Set headers
-        headers = {
-            "Content-Type": "application/dicom+json",
-            "Accept": "application/dicom+json",
-        }
+        headers = self._make_headers()
 
         return self._send_request("POST", endpoint, headers=headers, json_data=workitem_data, success_code=201)
 
@@ -283,7 +248,10 @@ class UPSRSClient:
         endpoint = f"{self.base_url}/workitems/{workitem_uid}"
 
         # Set headers according to DICOM PS3.18 specification
-        headers = {"Accept": "application/dicom+json", "Cache-Control": "no-cache"}
+        # Override Accept to include Cache-Control; Content-Type is not needed for GET
+        headers = self._make_headers(extra={"Cache-Control": "no-cache"})
+        # GET requests should not send Content-Type
+        headers.pop("Content-Type", None)
 
         return self._send_request("GET", endpoint, headers=headers)
 
@@ -332,12 +300,12 @@ class UPSRSClient:
         # Set endpoint URL with query parameters
         endpoint = f"{self.base_url}/workitems?{urlencode(params, doseq=True)}"
 
-        # Set headers
-        headers = {"Accept": "application/dicom+json"}
-
-        # Add Cache-Control header if no_cache is True
+        # Build headers — GET does not send a body, so no Content-Type
+        extra: dict[str, str] = {}
         if no_cache:
-            headers["Cache-Control"] = "no-cache"
+            extra["Cache-Control"] = "no-cache"
+        headers = self._make_headers(extra=extra)
+        headers.pop("Content-Type", None)
 
         success, response = self._send_request("GET", endpoint, headers=headers)
 
@@ -388,11 +356,7 @@ class UPSRSClient:
             # or test its response to a missing transaction uid when it is required
             endpoint = f"{self.base_url}/workitems/{workitem_uid}"
 
-        # Set headers
-        headers = {
-            "Content-Type": "application/dicom+json",
-            "Accept": "application/dicom+json",
-        }
+        headers = self._make_headers()
 
         return self._send_request("PUT", endpoint, headers=headers, json_data=update_data)
 
@@ -450,14 +414,10 @@ class UPSRSClient:
         # Set endpoint URL
         endpoint = f"{self.base_url}/workitems/{workitem_uid}/state"
 
-        # Set headers
-        headers = {
-            "Content-Type": "application/dicom+json",
-            "Accept": "application/dicom+json",
-        }
+        headers = self._make_headers()
 
         # Prepare payload
-        payload = {
+        payload: dict[str, Any] = {
             # Procedure Step State (0074,1000)
             "00741000": {"vr": "CS", "Value": [new_state]}
         }
@@ -502,7 +462,7 @@ class UPSRSClient:
         endpoint = f"{self.base_url}/workitems/{workitem_uid}/cancelrequest"
 
         # Prepare payload with cancellation request information
-        payload = {}
+        payload: dict[str, Any] = {}
 
         # Add Reason For Cancellation (0074,1238) if provided
         if reason:
@@ -516,11 +476,7 @@ class UPSRSClient:
         if contact_uri:
             payload["0074100F"] = {"vr": "UT", "Value": [contact_uri]}
 
-        # Set headers
-        headers = {
-            "Content-Type": "application/dicom+json",
-            "Accept": "application/dicom+json",
-        }
+        headers = self._make_headers()
 
         return self._send_request("POST", endpoint, headers=headers, json_data=payload, success_code=202)
 
@@ -806,14 +762,7 @@ class UPSRSClient:
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(
             self.executor,
-            lambda: self.search_workitems(
-                match_parameters,
-                include_fields,
-                fuzzy_matching,
-                offset,
-                limit,
-                no_cache,
-            ),
+            lambda: self.search_workitems(match_parameters, include_fields, fuzzy_matching, offset, limit, no_cache),
         )
 
     async def update_workitem_async(
@@ -827,7 +776,7 @@ class UPSRSClient:
 
         Args:
             workitem_uid: UID of the workitem to update
-            transaction_uid: Transaction UID (required for updates to IN PROGRESS workitems)
+            transaction_uid: Transaction UID for the update
             update_data: dictionary containing the workitem attributes to update
 
         Returns:
@@ -836,8 +785,7 @@ class UPSRSClient:
         """
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(
-            self.executor,
-            lambda: self.update_workitem(workitem_uid, transaction_uid, update_data),
+            self.executor, lambda: self.update_workitem(workitem_uid, transaction_uid, update_data)
         )
 
     async def change_workitem_state_async(
@@ -850,7 +798,7 @@ class UPSRSClient:
         Asynchronously change the state of a workitem on the UPS-RS server.
 
         Args:
-            workitem_uid: UID of the workitem to change
+            workitem_uid: UID of the workitem to update
             new_state: New state for the workitem
             transaction_uid: Transaction UID (required for state changes)
 
@@ -947,18 +895,25 @@ class UPSRSClient:
         self,
         method: str,
         url: str,
-        headers: dict[str, str] = None,
+        headers: dict[str, str] | None = None,
         json_data: Any = None,  # noqa: ANN401
         success_code: int = 200,
     ) -> tuple[bool, dict[str, Any] | str]:
         """
         Send an HTTP request to the UPS-RS server with retry logic.
 
+        When ``self.content_type`` is ``application/dicom+xml`` and ``json_data``
+        is provided, the body is serialised to XML via
+        ``dicom_ups_rs_client.serialization.serialize_request`` and sent as raw
+        bytes.  Response parsing similarly dispatches on the response Content-Type
+        header via ``dicom_ups_rs_client.serialization.parse_response_body``.
+
         Args:
             method: HTTP method (GET, POST, PUT, DELETE)
             url: The URL to send the request to
             headers: Optional HTTP headers
-            json_data: Optional JSON data to send
+            json_data: Optional data to send. Will be serialised to XML when the
+                negotiated content type is ``application/dicom+xml``.
             success_code: Expected HTTP status code for success
 
         Returns:
@@ -968,7 +923,12 @@ class UPSRSClient:
         retry_count = 0
         while retry_count <= self.max_retries:
             try:
-                response = self.session.request(method, url, headers=headers, json=json_data, timeout=self.timeout)
+                # Determine how to pass the body
+                if json_data is not None and self.content_type == CONTENT_TYPE_XML:
+                    body_bytes = serialize_request(json_data, self.content_type)
+                    response = self.session.request(method, url, headers=headers, data=body_bytes, timeout=self.timeout)
+                else:
+                    response = self.session.request(method, url, headers=headers, json=json_data, timeout=self.timeout)
 
                 for key, value in response.headers.items():
                     self.logger.debug(f"Response headers: {key}: {value}")
@@ -980,97 +940,42 @@ class UPSRSClient:
                 # Check response status
                 if response.status_code == success_code:
                     self.logger.info(f"Request to {url} successful")
-
-                    try:
-                        result = response.json() if response.text else {"status": "Success"}
-                    except json.JSONDecodeError:
-                        result = {"status": "Success", "response_text": response.text}
-
-                    # Add headers of interest
-                    for header in ["Content-Location", "Location", "Warning"]:
-                        header_lower = header.lower()
-                        if header_lower in response.headers:
-                            self.logger.info(f"Response header {header_lower}: {response.headers.get(header_lower)}")
-                            result[header_lower.replace("-", "_")] = response.headers.get(header_lower)
-                            snake_case_header = header_lower.replace("-", "_")
-                            self.logger.info(
-                                f"Added {header_lower} to result in {snake_case_header}: {result[snake_case_header]}"
-                            )
-
-                    return True, result
+                    parsed_success = self._parse_success_response(response, url)
+                    return True, parsed_success  # type: ignore[return-value]
 
                 # Handle no content (204) and partial content (206) specially
-                elif response.status_code == 204:
-                    result = {"status_code": response.status_code}
-                    result["message"] = "No Content"
-                    try:
-                        if response.text:
-                            result["data"] = response.json()
-                    except json.JSONDecodeError:
-                        self.logger.warning(
-                            "Unexpected: received non-JSON body in 204 No Content response from %s; body discarded",
-                            url,
-                        )
+                if response.status_code == 204:
+                    return True, self._parse_no_content_response(response, url)
 
-                    return True, result
-                # For partial content (status code 206)
-                elif response.status_code == 206:
-                    try:
-                        # Parse the JSON response
-                        result_list = response.json()
-
-                        # Log warning about partial results
-                        self.logger.info("Partial results received. There may be more results available.")
-                        if "Warning" in response.headers:
-                            self.logger.debug(f"Server warning: {response.headers['Warning']}")
-
-                        # Return just the list of results (to match 200 OK behavior)
-                        return True, result_list
-                    except json.JSONDecodeError:
-                        # Handle parsing error
+                if response.status_code == 206:
+                    parsed = self._parse_partial_content_response(response)
+                    if parsed is None:
                         return False, "Failed to parse partial content response"
+                    return True, parsed
 
+                # Error response handling
+                brief_error_msg = f"Failed request to {url}. Status code: {response.status_code}"
+                error_msg = self._build_error_message(brief_error_msg, response)
+
+                if warning_header:
+                    error_msg = f"{error_msg}, Warning: {warning_header}"
+
+                # Don't retry client errors except timeout (408) and too many requests (429)
+                if 400 <= response.status_code < 500 and response.status_code not in [408, 429]:
+                    self.logger.error(error_msg)
+                    return False, error_msg
+
+                # For other errors, retry if we haven't exceeded max retries
+                if retry_count < self.max_retries:
+                    retry_count += 1
+                    self.logger.warning(f"{brief_error_msg}. Retrying ({retry_count}/{self.max_retries})...")
+                    self.logger.debug(f"Full error details: {error_msg}")
+                    time.sleep(self.retry_delay * retry_count)  # Exponential backoff
+                    continue
                 else:
-                    brief_error_msg = f"Failed request to {url}. Status code: {response.status_code}"
-                    error_msg = brief_error_msg
-                    if response.text:
-                        try:
-                            error_details = response.json() if response.text else {}
-                            if error_details:
-                                self.logger.debug(f"Response details: {error_details}")
-                                error_msg += f". Error details: {error_details}"
-                            else:
-                                error_msg += f". Response: {response.text}"
-                            # return False, error_msg
-                        except json.JSONDecodeError:
-                            error_msg = f"{error_msg}, Response: {response.text}"
-                            #  return False, error_msg
-                        except ValueError:
-                            # Handle case where error response is not JSON
-                            error_msg = (
-                                f"Failed request to {url}. Status code: {response.status_code}. Response: {response.text}"
-                            )
-                        # return False, error_msg
-
-                    if warning_header:
-                        error_msg = f"{error_msg}, Warning: {warning_header}"
-
-                    # Don't retry client errors except timeout (408) and too many requests (429)
-                    if 400 <= response.status_code < 500 and response.status_code not in [408, 429]:
-                        self.logger.error(error_msg)
-                        return False, error_msg
-
-                    # For other errors, retry if we haven't exceeded max retries
-                    if retry_count < self.max_retries:
-                        retry_count += 1
-                        self.logger.warning(f"{brief_error_msg}. Retrying ({retry_count}/{self.max_retries})...")
-                        self.logger.debug(f"Full error details: {error_msg}")
-                        time.sleep(self.retry_delay * retry_count)  # Exponential backoff
-                        continue
-                    else:
-                        error_msg = f"{error_msg}. Max retries exceeded."
-                        self.logger.error(f"{error_msg}")
-                        return False, error_msg
+                    error_msg = f"{error_msg}. Max retries exceeded."
+                    self.logger.error(f"{error_msg}")
+                    return False, error_msg
 
             except requests.RequestException as e:
                 error_msg = f"Request error: {str(e)}"
@@ -1087,6 +992,147 @@ class UPSRSClient:
 
         # This should not be reached, but just in case
         return False, "Unknown error occurred during request"
+
+    def _parse_success_response(self, response: requests.Response, url: str) -> dict[str, Any] | list[Any]:
+        """
+        Parse the body of a successful HTTP response.
+
+        The parsing strategy is determined by the response ``Content-Type`` header:
+        - ``application/dicom+xml`` → parse as a single DICOM XML document.
+        - ``multipart/related`` → parse as multipart DICOM XML.
+        - Anything else (including empty body) → JSON or a default success dict.
+
+        After parsing, selected response headers (``Content-Location``,
+        ``Location``, ``Warning``) are merged into the result dict when the
+        parsed body is a dict.  When the body is a list (e.g. search results),
+        these headers are not merged (they are not expected in that case).
+
+        Args:
+            response: The successful HTTP response object.
+            url: The request URL, used only for log messages.
+
+        Returns:
+            A dict or list containing the parsed response body.
+            When the body is a dict, selected response headers are also
+            included as keys.
+
+        """
+        response_content_type = response.headers.get("Content-Type", "")
+
+        parsed_result: dict[str, Any] | list[Any]
+
+        if not response.text:
+            parsed_result = {"status": "Success"}
+        else:
+            try:
+                parsed = parse_response_body(response.content, response.text, response_content_type)
+                # parse_response_body may return a Dataset or list[Dataset] for XML
+                if isinstance(parsed, Dataset):
+                    parsed_result = json.loads(parsed.to_json())
+                elif isinstance(parsed, list) and parsed and isinstance(parsed[0], Dataset):
+                    # Multipart XML search response — convert each Dataset to JSON-dict
+                    parsed_result = [json.loads(ds.to_json()) for ds in parsed]
+                elif isinstance(parsed, list):
+                    parsed_result = parsed
+                elif isinstance(parsed, dict):
+                    parsed_result = parsed
+                else:
+                    parsed_result = {"data": parsed}
+            except (json.JSONDecodeError, Exception):
+                parsed_result = {"status": "Success", "response_text": response.text}
+
+        # Add headers of interest — only when parsed_result is a dict
+        if isinstance(parsed_result, dict):
+            for header in ["Content-Location", "Location", "Warning"]:
+                header_lower = header.lower()
+                if header_lower in response.headers:
+                    self.logger.info(f"Response header {header_lower}: {response.headers.get(header_lower)}")
+                    parsed_result[header_lower.replace("-", "_")] = response.headers.get(header_lower)
+                    snake_case_header = header_lower.replace("-", "_")
+                    self.logger.info(
+                        f"Added {header_lower} to result in {snake_case_header}: {parsed_result[snake_case_header]}"
+                    )
+
+        return parsed_result
+
+    def _parse_no_content_response(self, response: requests.Response, url: str) -> dict[str, Any]:
+        """
+        Parse a 204 No Content response.
+
+        Args:
+            response: The HTTP response with status 204.
+            url: The request URL, used only for log messages.
+
+        Returns:
+            A dict with ``status_code`` and ``message``, and optionally ``data``.
+
+        """
+        result: dict[str, Any] = {"status_code": response.status_code, "message": "No Content"}
+        if response.text:
+            try:
+                result["data"] = json.loads(response.text)
+            except json.JSONDecodeError:
+                self.logger.warning(
+                    "Unexpected: received non-JSON body in 204 No Content response from %s; body discarded",
+                    url,
+                )
+        return result
+
+    def _parse_partial_content_response(self, response: requests.Response) -> list[Any] | None:
+        """
+        Parse a 206 Partial Content response.
+
+        Args:
+            response: The HTTP response with status 206.
+
+        Returns:
+            A list of parsed results, or ``None`` if parsing fails.
+
+        """
+        response_content_type = response.headers.get("Content-Type", "")
+        try:
+            parsed = parse_response_body(response.content, response.text, response_content_type)
+        except (json.JSONDecodeError, Exception):
+            return None
+
+        self.logger.info("Partial results received. There may be more results available.")
+        if "Warning" in response.headers:
+            self.logger.debug(f"Server warning: {response.headers['Warning']}")
+
+        if isinstance(parsed, list):
+            return parsed
+        return [parsed]
+
+    def _build_error_message(self, brief_error_msg: str, response: requests.Response) -> str:
+        """
+        Build a descriptive error message from a non-success HTTP response.
+
+        Error responses from servers always use JSON (the server may return JSON
+        error bodies even when XML was requested), so we attempt JSON parsing first
+        and fall back to the raw response text.
+
+        Args:
+            brief_error_msg: Short message identifying the failing request.
+            response: The HTTP error response object.
+
+        Returns:
+            A string describing the error, including any available details.
+
+        """
+        error_msg = brief_error_msg
+        if response.text:
+            try:
+                error_details = json.loads(response.text)
+                if error_details:
+                    self.logger.debug(f"Response details: {error_details}")
+                    error_msg += f". Error details: {error_details}"
+                else:
+                    error_msg += f". Response: {response.text}"
+            except json.JSONDecodeError:
+                error_msg = f"{error_msg}, Response: {response.text}"
+            except ValueError:
+                error_msg = f"{brief_error_msg}. Response: {response.text}"
+        return error_msg
 
     def _construct_default_websocket_url(
         self,
@@ -1246,6 +1292,8 @@ class UPSRSClient:
         """
         Process incoming WebSocket messages with DICOM UPS-RS event notifications.
 
+        WebSocket messages are always application/dicom+json per PS3.18 Section 8.10.5.
+
         Args:
             message: The received message in DICOM+JSON format
 
@@ -1270,7 +1318,7 @@ class UPSRSClient:
 
                 def _run_callback() -> None:
                     with self._callback_lock:
-                        self.event_callback(event_data)
+                        self.event_callback(event_data)  # type: ignore[misc]
 
                 if threading.current_thread() is threading.main_thread():
                     _run_callback()
@@ -1297,7 +1345,7 @@ class UPSRSClient:
         retry_count = 0
 
         # Configure SSL context for WebSocket
-        ssl_context = None
+        ssl_context: ssl.SSLContext | None = None
         if self.ws_url and self.ws_url.startswith("wss://"):
             ssl_context = ssl.create_default_context()
 
@@ -1320,62 +1368,45 @@ class UPSRSClient:
             try:
                 self.logger.info(f"Connecting to WebSocket: {self.ws_url}")
 
-                # Pass SSL context to websockets.connect if needed
+                # Pass SSL context to websockets.connect only when needed
+                connect_kwargs: dict[str, Any] = {}
                 if ssl_context:
-                    async with websockets.connect(self.ws_url, ssl=ssl_context) as websocket:
-                        self.ws_connection = websocket
-                        self.logger.info("WebSocket connection established")
-                        retry_count = 0  # Reset retry counter on successful connection
+                    connect_kwargs["ssl"] = ssl_context
 
-                        # Keep receiving messages until connection is closed
-                        while self.running:
-                            try:
-                                message = await asyncio.wait_for(websocket.recv(), timeout=1.0)
-                                await self._handle_message(message)
-                            except TimeoutError:
-                                # No message received within timeout, check if we should continue
-                                if not self.running:
-                                    # Exit the inner loop immediately if shutdown was requested
-                                    break
-                                continue
-                            except websockets.exceptions.ConnectionClosed as e:
-                                self.logger.warning(f"WebSocket connection closed: {e}")
-                                break
-                else:
-                    async with websockets.connect(self.ws_url) as websocket:
-                        self.ws_connection = websocket
-                        self.logger.info("WebSocket connection established")
-                        retry_count = 0  # Reset retry counter on successful connection
+                async with websockets.connect(self.ws_url, **connect_kwargs) as websocket:
+                    self.ws_connection = websocket
+                    self.logger.info("WebSocket connection established")
+                    retry_count = 0  # Reset retry counter on successful connection
 
-                        # Keep receiving messages until connection is closed
-                        while self.running:
-                            try:
-                                message = await asyncio.wait_for(websocket.recv(), timeout=1.0)
-                                await self._handle_message(message)
-                            except TimeoutError:
-                                # No message received within timeout, check if we should continue
-                                if not self.running:
-                                    # Exit the inner loop immediately if shutdown was requested
-                                    break
-                                continue
-                            except websockets.exceptions.ConnectionClosed as e:
-                                self.logger.warning(f"WebSocket connection closed: {e}")
+                    # Keep receiving messages until connection is closed
+                    while self.running:
+                        try:
+                            message = await asyncio.wait_for(websocket.recv(), timeout=1.0)
+                            await self._handle_message(message)
+                        except TimeoutError:
+                            # No message received within timeout, check if we should continue
+                            if not self.running:
+                                # Exit the inner loop immediately if shutdown was requested
                                 break
+                            continue
+                        except websockets.exceptions.ConnectionClosed as e:
+                            self.logger.warning(f"WebSocket connection closed: {e}")
+                            break
+
                 # Check running flag again after inner loop ends
                 if not self.running:
                     break
+
             except (
                 websockets.exceptions.WebSocketException,
                 ConnectionRefusedError,
             ) as e:
                 if not self.running:
-                    break  # Exit if we're shutting down
+                    break
 
                 retry_count += 1
-                self.logger.error(f"WebSocket connection error: {str(e)}")
-
-                if retry_count >= max_retries:
-                    self.logger.error(f"Maximum retries ({max_retries}) reached. Giving up.")
+                if retry_count > max_retries:
+                    self.logger.error(f"Maximum retries exceeded. Last error: {e}")
                     self.running = False
                     break
 
@@ -1397,726 +1428,25 @@ class UPSRSClient:
         self.logger.info("WebSocket client stopped")
 
 
+# Keep backward-compatible entry points — the real implementations are in cli.py
+def main() -> None:
+    """Execute the CLI entry point.  Implementation lives in :mod:`dicom_ups_rs_client.cli`."""
+    from dicom_ups_rs_client.cli import main as _main
+
+    _main()
+
+
 def _event_handler(event_data: dict[str, Any]) -> None:
     """
-    Handle incoming UPS-RS events.
+    Handle incoming UPS-RS events (re-exported from cli module for backward compatibility).
 
     Args:
         event_data: dictionary containing event information
 
     """
-    try:
-        event_type_id = event_data.get("00001002", {}).get("Value", ["unknown"])[0]
-        affected_sop_instance_uid = event_data.get("00001000", {}).get("Value", ["unknown"])[0]
-        print(f"\nEVENT RECEIVED: {event_type_id} - Workitem: {affected_sop_instance_uid}")
-    except (KeyError, IndexError):
-        print("\nEVENT RECEIVED: (unable to extract event type or workitem UID)")
+    from dicom_ups_rs_client.cli import _event_handler as _cli_event_handler
 
-    print(json.dumps(event_data, indent=2))
-    print("-" * 60)
-
-
-def main() -> None:
-    """Execute Main CLI entry point for UPS-RS client."""
-    parser = argparse.ArgumentParser(description="DICOM UPS-RS Client")
-    parser.add_argument(
-        "--server",
-        type=str,
-        required=True,
-        help="URL of the UPS-RS server (e.g., http://localhost:5000)",
-    )
-    parser.add_argument(
-        "--aetitle",
-        type=str,
-        help="Application Entity Title for subscription operations",
-    )
-    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
-    parser.add_argument("--timeout", type=int, default=30, help="Request timeout in seconds")
-    parser.add_argument("--max-retries", type=int, default=3, help="Maximum number of request retries")
-
-    # Add SSL/TLS related arguments
-    parser.add_argument(
-        "--no-verify-ssl",
-        action="store_true",
-        help="Disable SSL certificate verification (not recommended)",
-    )
-    parser.add_argument(
-        "--ca-bundle",
-        type=str,
-        help="Path to CA bundle file for SSL verification",
-    )
-    parser.add_argument(
-        "--client-cert",
-        type=str,
-        help="Path to client certificate file (.pem with both cert and key)",
-    )
-    parser.add_argument(
-        "--client-cert-key",
-        type=str,
-        help="Path to separate client key file (use with --client-cert for separate files)",
-    )
-    parser.add_argument(
-        "--websocket-url-override",
-        type=str,
-        help="Override WebSocket URL template. Use {aetitle} as placeholder. Example: wss://example.com:9443/ws/subscribers/{aetitle}",
-    )
-
-    # Create subparsers for different commands
-    subparsers = parser.add_subparsers(dest="command", help="Command to execute")
-
-    # Create workitem command
-    create_parser = subparsers.add_parser("create", help="Create a new workitem")
-    create_parser.add_argument("--workitem-uid", type=str, help="Optional UID for the workitem")
-    create_parser.add_argument("--input-file", type=str, help="JSON file containing workitem data")
-    create_parser.add_argument("--input-dcm", type=str, help="DICOM file containing workitem data")
-
-    # Retrieve workitem command
-    retrieve_parser = subparsers.add_parser("retrieve", help="Retrieve a workitem")
-    retrieve_parser.add_argument(
-        "--workitem-uid",
-        type=str,
-        required=True,
-        help="UID of the workitem to retrieve",
-    )
-    retrieve_parser.add_argument(
-        "--output-file",
-        type=str,
-        help="Output file to save the retrieved workitem JSON",
-    )
-
-    # Search workitems command
-    search_parser = subparsers.add_parser("search", help="Search for workitems")
-    search_parser.add_argument(
-        "--match",
-        action="append",
-        help="Match parameters (e.g., '00741000=SCHEDULED')",
-        default=[],
-    )
-    search_parser.add_argument(
-        "--includefield",
-        action="append",
-        help="Fields to include in results",
-        default=[],
-    )
-    search_parser.add_argument("--fuzzy", action="store_true", help="Enable fuzzy matching")
-    search_parser.add_argument(
-        "--state",
-        choices=["SCHEDULED", "IN PROGRESS", "CANCELED", "COMPLETED"],
-        help="Filter by Procedure Step State (00741000)",
-    )
-    search_parser.add_argument(
-        "--readiness",
-        choices=["READY", "UNAVAILABLE", "INCOMPLETE"],
-        help="Filter by Input Readiness State (00404041)",
-    )
-    search_parser.add_argument(
-        "--start-date",
-        type=str,
-        help="Filter by Scheduled Start Date (00404005) in YYYYMMDD format",
-    )
-    search_parser.add_argument("--label", type=str, help="Filter by Procedure Step Label (00741204)")
-    search_parser.add_argument("--offset", type=int, default=0, help="Starting position of results")
-    search_parser.add_argument("--limit", type=int, help="Maximum number of results to return")
-    search_parser.add_argument("--no-cache", action="store_true", help="Request non-cached results")
-    search_parser.add_argument("--output-file", type=str, help="Output file to save search results")
-    search_parser.add_argument("--summary", action="store_true", help="Display only a summary of results")
-    search_parser.add_argument(
-        "--display-fields",
-        type=str,
-        help="Comma-separated list of fields to display in output summary",
-    )
-
-    # Update workitem command
-    update_parser = subparsers.add_parser("update", help="Update a workitem")
-    update_parser.add_argument("--workitem-uid", type=str, required=True, help="UID of the workitem to update")
-    update_parser.add_argument("--transaction-uid", type=str, help="Transaction UID")
-    update_parser.add_argument("--input-file", type=str, help="JSON file containing update data")
-    update_parser.add_argument("--procedure-label", type=str, help="Set the Procedure Step Label (0074,1204)")
-    update_parser.add_argument(
-        "--procedure-description",
-        type=str,
-        help="Set the Procedure Step Description (0040,0007)",
-    )
-
-    # Change workitem state command
-    state_parser = subparsers.add_parser("change-state", help="Change workitem state")
-    state_parser.add_argument(
-        "--workitem-uid",
-        type=str,
-        required=True,
-        help="UID of the workitem to change state",
-    )
-    state_parser.add_argument(
-        "--state",
-        type=str,
-        required=True,
-        choices=["IN PROGRESS", "COMPLETED", "CANCELED"],
-        help="New state for the workitem",
-    )
-    state_parser.add_argument(
-        "--transaction-uid",
-        type=str,
-        help="Transaction UID (required for COMPLETED/CANCELED states, optional for IN PROGRESS)",
-    )
-
-    # Request cancellation command
-    cancel_parser = subparsers.add_parser("request-cancel", help="Request cancellation of a workitem")
-    cancel_parser.add_argument(
-        "--workitem-uid",
-        type=str,
-        required=True,
-        help="UID of the workitem to request cancellation for",
-    )
-    cancel_parser.add_argument("--reason", type=str, help="Reason for the cancellation request")
-    cancel_parser.add_argument("--contact-name", type=str, help="Display name of the contact person")
-    cancel_parser.add_argument(
-        "--contact-uri",
-        type=str,
-        help="URI for contacting the requestor (e.g., mailto:user@example.com)",
-    )
-
-    # Subscribe command
-    subscribe_parser = subparsers.add_parser("subscribe", help="Subscribe to workitem events")
-    subscribe_group = subscribe_parser.add_mutually_exclusive_group(required=True)
-    subscribe_group.add_argument("--worklist", action="store_true", help="Subscribe to the entire worklist")
-    subscribe_group.add_argument(
-        "--filtered-worklist",
-        action="store_true",
-        help="Subscribe to a filtered worklist",
-    )
-    subscribe_group.add_argument("--workitem", type=str, help="UID of a specific workitem to subscribe to")
-    subscribe_parser.add_argument(
-        "--filter",
-        action="append",
-        help="Filter parameters for filtered worklist (e.g., '00741000=SCHEDULED')",
-        default=[],
-    )
-    subscribe_parser.add_argument(
-        "--deletion-lock",
-        action="store_true",
-        help="Request deletion lock for the subscription",
-    )
-    subscribe_parser.add_argument(
-        "--monitor",
-        action="store_true",
-        help="Monitor for event notifications after subscribing",
-    )
-
-    # Unsubscribe command
-    unsubscribe_parser = subparsers.add_parser("unsubscribe", help="Unsubscribe from workitem events")
-    unsubscribe_group = unsubscribe_parser.add_mutually_exclusive_group(required=True)
-    unsubscribe_group.add_argument("--worklist", action="store_true", help="Unsubscribe from the entire worklist")
-    unsubscribe_group.add_argument(
-        "--filtered-worklist",
-        action="store_true",
-        help="Unsubscribe from a filtered worklist",
-    )
-    unsubscribe_group.add_argument("--workitem", type=str, help="UID of a specific workitem to unsubscribe from")
-    unsubscribe_parser.add_argument(
-        "--filter",
-        action="append",
-        help="Filter parameters for filtered worklist (e.g., '00741000=SCHEDULED')",
-        default=[],
-    )
-    unsubscribe_parser.add_argument(
-        "--deletion-lock",
-        action="store_true",
-        help="Request deletion lock for the unsubscription",
-    )
-
-    args = parser.parse_args()
-
-    # Set up logging
-    log_level = logging.DEBUG if args.verbose else logging.INFO
-    logging.basicConfig(level=log_level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-
-    # Check for required command
-    if not args.command:
-        parser.print_help()
-        sys.exit(1)
-
-    # Determine SSL verification setting
-    verify_ssl = True
-    if args.no_verify_ssl:
-        verify_ssl = False
-    elif args.ca_bundle:
-        verify_ssl = args.ca_bundle
-
-    # Validate client certificate arguments
-    if args.client_cert_key and not args.client_cert:
-        parser.error("--client-cert-key requires --client-cert to also be specified")
-
-    # Determine client certificate setting
-    client_cert = None
-    if args.client_cert:
-        if args.client_cert_key:
-            client_cert = (args.client_cert, args.client_cert_key)
-        else:
-            client_cert = args.client_cert
-
-    # Initialize client with SSL settings
-    client = UPSRSClient(
-        base_url=args.server,
-        aetitle=args.aetitle,
-        timeout=args.timeout,
-        max_retries=args.max_retries,
-        verify_ssl=verify_ssl,
-        client_cert=client_cert,
-        websocket_url_override=args.websocket_url_override,
-    )
-
-    try:
-        # Execute the requested command
-        if args.command == "create":
-            _handle_create_command(client, args)
-        elif args.command == "retrieve":
-            _handle_retrieve_command(client, args)
-        elif args.command == "search":
-            _handle_search_command(client, args)
-        elif args.command == "update":
-            _handle_update_command(client, args)
-        elif args.command == "change-state":
-            _handle_change_state_command(client, args)
-        elif args.command == "request-cancel":
-            _handle_cancel_request_command(client, args)
-        elif args.command == "subscribe":
-            _handle_subscribe_command(client, args)
-        elif args.command == "unsubscribe":
-            _handle_unsubscribe_command(client, args)
-    finally:
-        # Ensure proper cleanup
-        client.close()
-
-
-def _handle_create_command(client: UPSRSClient, args: argparse.Namespace) -> None:
-    """Handle the create workitem command."""
-    # Generate a DICOM UID if one wasn't provided on the command line
-    workitem_uid = args.workitem_uid or str(generate_uid())
-
-    # Load workitem data if provided
-    workitem_data = None
-    if args.input_file:
-        try:
-            with open(args.input_file) as f:
-                workitem_data = json.load(f)
-        except Exception as e:
-            logging.error(f"Failed to load workitem data from {args.input_file}: {str(e)}")
-            sys.exit(1)
-
-    if args.input_dcm:
-        try:
-            dcm_path = Path(args.input_dcm)
-            local_json_path = Path(dcm_path.name.removesuffix("dcm") + "json")
-
-            workitem_ds = dcmread(args.input_dcm)
-            # Make sure the workitem_uid is consistent in the post and the data
-            if not args.workitem_uid:
-                workitem_uid = str(workitem_ds.SOPInstanceUID)
-            else:
-                workitem_ds.SOPInstanceUID = workitem_uid
-            workitem_uid = workitem_uid or str(generate_uid())
-
-            workitem_data = json.loads(workitem_ds.to_json())
-            local_json_path.write_text(json.dumps(workitem_data, indent=2))
-
-        except Exception as e:
-            logging.error(f"Failed to load workitem data from {args.input_dcm}: {str(e)}")
-            sys.exit(1)
-
-    # Create workitem
-    success, response = client.create_workitem(workitem_data, workitem_uid)
-
-    if success:
-        print("Workitem created successfully")
-        print(json.dumps(response, indent=2))
-        print(f"Workitem UID: {workitem_uid}")
-        sys.exit(0)
-    else:
-        print(f"Failed to create workitem: {response}")
-        sys.exit(1)
-
-
-def _handle_retrieve_command(client: UPSRSClient, args: argparse.Namespace) -> None:
-    """Handle the retrieve workitem command."""
-    success, response = client.retrieve_workitem(args.workitem_uid)
-
-    if success:
-        print("Workitem retrieved successfully")
-        formatted_response = json.dumps(response, indent=2)
-        print(formatted_response)
-
-        # Save to file if requested
-        if args.output_file:
-            try:
-                with open(args.output_file, "w") as f:
-                    f.write(formatted_response)
-                print(f"Workitem saved to {args.output_file}")
-            except Exception as e:
-                print(f"Failed to save workitem to file: {str(e)}")
-                sys.exit(1)
-
-        sys.exit(0)
-    else:
-        print(f"Failed to retrieve workitem: {response}")
-        sys.exit(1)
-
-
-def _handle_search_command(client: UPSRSClient, args: argparse.Namespace) -> None:
-    """Handle the search workitems command."""
-    # Parse match parameters
-    match_parameters = {}
-    for param in args.match:
-        if "=" in param:
-            key, value = param.split("=", 1)
-            match_parameters[key] = value
-        else:
-            logging.warning(f"Ignoring invalid match parameter (missing '='): {param}")
-
-    # Add common search parameters if provided
-    if args.state:
-        match_parameters["00741000"] = args.state
-
-    if args.readiness:
-        match_parameters["00404041"] = args.readiness
-
-    if args.start_date:
-        match_parameters["00404005"] = args.start_date
-
-    if args.label:
-        match_parameters["00741204"] = args.label
-
-    # Inform user about search criteria
-    _summarize_search_criteria(match_parameters)
-
-    # Perform search
-    success, response = client.search_workitems(
-        match_parameters,
-        args.includefield,
-        args.fuzzy,
-        args.offset,
-        args.limit,
-        args.no_cache,
-    )
-
-    if not success:
-        print(f"Failed to search workitems: {response}")
-        sys.exit(1)
-
-    if isinstance(response, list) and response:
-        result_count = len(response)
-        print(f"Search returned {result_count} result(s)")
-
-        # Display summary if requested or full results
-        if args.summary:
-            _summarize_search_results(args, response)
-        else:
-            # Print full formatted results
-            formatted_response = json.dumps(response, indent=2)
-            print(formatted_response)
-
-        # Save to file if requested
-        if args.output_file:
-            try:
-                with open(args.output_file, "w") as f:
-                    f.write(json.dumps(response, indent=2))
-                print(f"Search results saved to {args.output_file}")
-            except Exception as e:
-                print(f"Failed to save search results to file: {str(e)}")
-                sys.exit(1)
-    else:
-        print("No matching workitems found")
-
-    sys.exit(0)
-
-
-def _summarize_search_criteria(match_parameters: dict[str, str]) -> None:
-    """Print a summary of the search criteria."""
-    if match_parameters:
-        print("Searching with criteria:")
-        for tag, value in match_parameters.items():
-            tag_name = ""
-            if tag == "00741000":
-                tag_name = "Procedure Step State"
-            elif tag == "00404041":
-                tag_name = "Input Readiness State"
-            elif tag == "00404005":
-                tag_name = "Scheduled Start Date"
-            elif tag == "00741204":
-                tag_name = "Procedure Step Label"
-
-            if tag_name:
-                print(f"  {tag_name} ({tag}) = {value}")
-            else:
-                print(f"  {tag} = {value}")
-    else:
-        print("Searching with no criteria (will return all workitems)")
-
-
-def _summarize_search_results(args: argparse.Namespace, response: list[dict[str, Any]]) -> None:
-    """Print a summary of the search results."""
-    print("\nSummary of Workitems:")
-    print("-" * 80)
-
-    # Determine which fields to display in summary
-    display_fields = []
-    display_fields = (
-        args.display_fields.split(",") if args.display_fields else ["00080018", "00741000", "00404041", "00741204"]
-    )
-    # Print header
-    header_row = []
-    for field in display_fields:
-        if field == "00080018":
-            header_row.append("SOP Instance UID")
-        elif field == "00404005":
-            header_row.append("Scheduled Start")
-        elif field == "00404041":
-            header_row.append("Input Readiness")
-        elif field == "00741000":
-            header_row.append("Procedure Step State")
-        elif field == "00741204":
-            header_row.append("Procedure Label")
-        else:
-            header_row.append(field)
-
-    print(" | ".join(header_row))
-    print("-" * 80)
-
-    # Print each workitem
-    for wi in response:
-        row = []
-        for field in display_fields:
-            if field in wi and "Value" in wi[field] and wi[field]["Value"]:
-                value = wi[field]["Value"][0]
-                # Truncate long values
-                if isinstance(value, str) and len(value) > 30:
-                    value = f"{value[:27]}..."
-                row.append(str(value))
-            else:
-                row.append("N/A")
-
-        print(" | ".join(row))
-
-    print("-" * 80)
-
-
-def _handle_update_command(client: UPSRSClient, args: argparse.Namespace) -> None:
-    """Handle the update workitem command."""
-    # Prepare update data
-    update_data = {}
-
-    # Load from file if provided
-    if args.input_file:
-        try:
-            with open(args.input_file) as f:
-                update_data = json.load(f)
-        except Exception as e:
-            logging.error(f"Failed to load update data from {args.input_file}: {str(e)}")
-            sys.exit(1)
-
-    # Add command line attributes if provided
-    if args.procedure_label:
-        update_data["00741204"] = {"vr": "LO", "Value": [args.procedure_label]}
-
-    if args.procedure_description:
-        update_data["00400007"] = {"vr": "LO", "Value": [args.procedure_description]}
-
-    if not args.transaction_uid:
-        print("Transaction UID not provided, only valid if UPS is SCHEDULED")
-
-    # Ensure we have some update data
-    if not update_data:
-        logging.error("No update data provided. Use --input-file or command line options.")
-        sys.exit(1)
-
-    # Update workitem
-    success, response = client.update_workitem(args.workitem_uid, args.transaction_uid, update_data)
-
-    if success:
-        print("Workitem updated successfully")
-
-        # Display any warnings
-        if isinstance(response, dict) and "warning" in response:
-            print(f"Warning: {response['warning']}")
-
-        # Display full response if available and verbose
-        if args.verbose and isinstance(response, dict) and "response" in response:
-            print("\nFull response:")
-            print(json.dumps(response["response"], indent=2))
-
-        sys.exit(0)
-    else:
-        print(f"Failed to update workitem: {response}")
-        sys.exit(1)
-
-
-def _handle_change_state_command(client: UPSRSClient, args: argparse.Namespace) -> None:
-    """Handle the change workitem state command."""
-    # Change workitem state
-    success, response = client.change_workitem_state(args.workitem_uid, args.state, args.transaction_uid)
-
-    if success:
-        print(f"Workitem state changed successfully to {args.state}")
-
-        # Display transaction UID for future reference
-        if isinstance(response, dict) and "transaction_uid" in response:
-            print(f"Transaction UID: {response['transaction_uid']}")
-            print("Keep this UID for future state changes to this workitem")
-
-        # Display any warnings
-        if isinstance(response, dict) and "warning" in response:
-            print(f"Warning: {response['warning']}")
-
-        # Display full response if verbose
-        if args.verbose and isinstance(response, dict) and "response" in response:
-            print("\nFull response:")
-            print(json.dumps(response["response"], indent=2))
-
-        sys.exit(0)
-    else:
-        print(f"Failed to change workitem state: {response}")
-        sys.exit(1)
-
-
-def _handle_cancel_request_command(client: UPSRSClient, args: argparse.Namespace) -> None:
-    """Handle the request cancellation command."""
-    # Request cancellation
-    success, response = client.request_cancellation(args.workitem_uid, args.reason, args.contact_name, args.contact_uri)
-
-    if not success:
-        print(f"Failed to request cancellation: {response}")
-        sys.exit(1)
-
-    print("Cancellation request sent successfully")
-
-    # Display any warnings
-    if isinstance(response, dict) and "warning" in response:
-        print(f"Warning: {response['warning']}")
-
-    # Display full response if available and verbose
-    if args.verbose and isinstance(response, dict) and "response" in response:
-        print("\nFull response:")
-        print(json.dumps(response["response"], indent=2))
-
-    # Include note about processing
-    print("\nNote: The cancellation request has been accepted by the server, but the workitem")
-    print("owner is not obliged to honor the request and may not receive notification.")
-
-    sys.exit(0)
-
-
-def _handle_subscribe_command(client: UPSRSClient, args: argparse.Namespace) -> None:
-    """Handle the subscribe command."""
-    # Check if AE Title is provided
-    if not args.aetitle:
-        print("Error: AE Title (--aetitle) is required for subscription operations")
-        sys.exit(1)
-
-    # Handle different subscription types
-    if args.worklist:
-        success, response = client.subscribe_to_worklist(args.deletion_lock)
-        subscription_type = "worklist"
-    elif args.filtered_worklist:
-        # Parse filter parameters
-        filter_params = {}
-        for param in args.filter:
-            if "=" in param:
-                key, value = param.split("=", 1)
-                filter_params[key] = value
-            else:
-                logging.warning(f"Ignoring invalid filter parameter (missing '='): {param}")
-
-        if not filter_params:
-            logging.error("Filtered worklist subscription requires at least one filter parameter")
-            sys.exit(1)
-
-        success, response = client.subscribe_to_filtered_worklist(filter_params, args.deletion_lock)
-        subscription_type = "filtered worklist"
-    else:  # workitem
-        success, response = client.subscribe_to_workitem(args.workitem, args.deletion_lock)
-        subscription_type = f"workitem {args.workitem}"
-
-    if success:
-        print(f"Successfully subscribed to {subscription_type}")
-
-        # Display WebSocket URL if available
-        if isinstance(response, dict) and "ws_url" in response:
-            print(f"WebSocket URL: {response['ws_url']}")
-
-        # Display any warnings
-        if isinstance(response, dict) and "warning" in response:
-            print(f"Warning: {response['warning']}")
-
-        # Start monitoring if requested
-        if args.monitor:
-            print("\nStarting event monitoring. Press Ctrl+C to stop.")
-
-            # Set up signal handler for graceful shutdown
-            def signal_handler(sig, frame) -> None:  # noqa: ANN001
-                print("\nShutting down...")
-                client.disconnect()
-                sys.exit(0)
-
-            signal.signal(signal.SIGINT, signal_handler)
-
-            # Connect to WebSocket and start receiving events
-            # assign a callback to perform application specific processing
-            client.connect_websocket(event_callback=_event_handler)
-
-            # Keep the main thread alive
-            try:
-                while True:
-                    time.sleep(1)
-            except KeyboardInterrupt:
-                client.disconnect()
-
-        sys.exit(0)
-    else:
-        print(f"Failed to subscribe to {subscription_type}: {response}")
-        sys.exit(1)
-
-
-def _handle_unsubscribe_command(client: UPSRSClient, args: argparse.Namespace) -> None:
-    """Handle the unsubscribe command."""
-    # Check if AE Title is provided
-    if not args.aetitle:
-        print("Error: AE Title (--aetitle) is required for subscription operations")
-        sys.exit(1)
-
-    # Handle different subscription types
-    if args.worklist:
-        success, response = client.unsubscribe_from_worklist(args.deletion_lock)
-        subscription_type = "worklist"
-    elif args.filtered_worklist:
-        # Parse filter parameters
-        filter_params = {}
-        for param in args.filter:
-            if "=" in param:
-                key, value = param.split("=", 1)
-                filter_params[key] = value
-            else:
-                logging.warning(f"Ignoring invalid filter parameter (missing '='): {param}")
-
-        if not filter_params:
-            logging.error("Filtered worklist subscription requires at least one filter parameter")
-            sys.exit(1)
-
-        success, response = client.unsubscribe_from_filtered_worklist(filter_params, args.deletion_lock)
-        subscription_type = "filtered worklist"
-    else:  # workitem
-        success, response = client.unsubscribe_from_workitem(args.workitem, args.deletion_lock)
-        subscription_type = f"workitem {args.workitem}"
-
-    if success:
-        print(f"Successfully unsubscribed from {subscription_type}")
-
-        # Display any warnings
-        if isinstance(response, dict) and "warning" in response:
-            print(f"Warning: {response['warning']}")
-
-        sys.exit(0)
-    else:
-        print(f"Failed to unsubscribe from {subscription_type}: {response}")
-        sys.exit(1)
+    _cli_event_handler(event_data)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "pydicom>=3.0.1,<4.0",
+    "pydicom-xml",
     "requests>=2.32.3, <3.0",
     "websockets>=15.0.1, <16.0",
 ]
@@ -52,6 +53,7 @@ Homepage = "https://github.com/yourusername/dicom-ups-rs-client"
 dev = [
     "pre-commit>=4.2.0",
     "pytest-asyncio>=0.26.0",
+    "pytest-json-report>=1.5.0",
     "ruff>=0.11.6",
     "setuptools>=80.3.1",
 ]
@@ -116,3 +118,6 @@ disallow_incomplete_defs = false
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"
+
+[tool.uv.sources]
+pydicom-xml = { git = "https://github.com/sjswerdloff/pydicom-xml", rev = "06032da" }

--- a/tests/test_xml_support.py
+++ b/tests/test_xml_support.py
@@ -203,13 +203,12 @@ class TestMakeHeaders:
         assert headers["Cache-Control"] == "no-cache"
         assert headers["Content-Type"] == CONTENT_TYPE_JSON
 
-    def test_extra_headers_do_not_override_content_type(self) -> None:
-        """Contract: extra dict cannot override Content-Type (last-write wins)."""
-        # The make_headers function merges extra AFTER setting the content-type
-        # keys, so extra CAN override them. This test documents current behavior.
-        headers = make_headers(CONTENT_TYPE_JSON, extra={"Content-Type": "text/plain"})
-        # extra overrides the default — document this as expected behavior
-        assert headers["Content-Type"] == "text/plain"
+    def test_extra_headers_cannot_override_content_type(self) -> None:
+        """Contract: extra dict cannot override Content-Type or Accept."""
+        headers = make_headers(CONTENT_TYPE_JSON, extra={"Content-Type": "text/plain", "Accept": "text/html"})
+        # Protected headers are filtered out — content_type always wins
+        assert headers["Content-Type"] == CONTENT_TYPE_JSON
+        assert headers["Accept"] == CONTENT_TYPE_JSON
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_xml_support.py
+++ b/tests/test_xml_support.py
@@ -1,0 +1,657 @@
+"""
+Tests for XML content-type support (application/dicom+xml).
+
+These tests verify the XML path through UPSRSClient without changing the
+existing JSON tests. All mocking happens at the HTTP session layer.
+
+Coverage plan:
+- _make_headers: XML and JSON modes
+- serialize_request: JSON dict → XML bytes, Dataset → XML bytes, JSON fallback
+- parse_response_body: XML single, multipart XML, JSON fallback
+- extract_boundary: normal, quoted, missing
+- _parse_multipart_xml: happy path, no boundary, malformed part
+- UPSRSClient (XML mode):
+  - create_workitem sends XML body with correct Content-Type
+  - retrieve_workitem sends correct Accept header
+  - search_workitems sends correct Accept header
+  - update_workitem sends XML body
+  - change_workitem_state sends XML body
+  - request_cancellation sends XML body
+- Response parsing dispatches on Content-Type header
+- Error responses always parsed as JSON
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from datetime import timedelta
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydicom import Dataset
+from pydicom_xml import from_xml, to_xml
+from requests.structures import CaseInsensitiveDict
+
+from dicom_ups_rs_client.serialization import (
+    CONTENT_TYPE_JSON,
+    CONTENT_TYPE_XML,
+    _parse_multipart_xml,
+    extract_boundary,
+    make_headers,
+    parse_response_body,
+    serialize_request,
+)
+from dicom_ups_rs_client.ups_rs_client import UPSRSClient
+from tests.conftest import MockSession
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SAMPLE_JSON: dict[str, Any] = {
+    "00741000": {"vr": "CS", "Value": ["SCHEDULED"]},
+    "00404041": {"vr": "CS", "Value": ["READY"]},
+}
+
+
+def _sample_dataset() -> Dataset:
+    return Dataset.from_json(json.dumps(_SAMPLE_JSON))
+
+
+def _sample_xml() -> bytes:
+    return to_xml(_sample_dataset())
+
+
+# ---------------------------------------------------------------------------
+# XML-specific mock response and fixtures
+# ---------------------------------------------------------------------------
+
+
+class XmlMockResponse:
+    """Mock for requests.Response that carries XML content."""
+
+    def __init__(
+        self,
+        status_code: int = 200,
+        xml_bytes: bytes = b"",
+        content_type: str = CONTENT_TYPE_XML,
+        extra_headers: dict[str, str] | None = None,
+    ) -> None:
+        """Initialize a mock XML response."""
+        self.status_code = status_code
+        self.content = xml_bytes
+        self.text = xml_bytes.decode("utf-8", errors="replace") if xml_bytes else ""
+        base_headers: dict[str, str] = {"Content-Type": content_type}
+        if extra_headers:
+            base_headers.update(extra_headers)
+        self.headers = CaseInsensitiveDict(base_headers)
+        self.reason = ""
+        self.url = "http://example.com/mock"
+        self.encoding = "utf-8"
+        self.elapsed = timedelta(milliseconds=100)
+        self.cookies: dict[str, str] = {}
+        self.history: list[Any] = []
+        self.request = None
+        self._json_data: dict[str, Any] | None = None
+
+    def json(self) -> dict[str, Any]:
+        """Return JSON data (not typically called for XML responses)."""
+        if self._json_data is None:
+            raise ValueError("No JSON data; this is an XML response")
+        return self._json_data
+
+    @property
+    def ok(self) -> bool:
+        """Return True if status code is 2xx."""
+        return 200 <= self.status_code < 400
+
+
+def _build_multipart_xml_body(datasets: list[Dataset], boundary: str) -> bytes:
+    """Build a multipart/related body with DICOM XML parts."""
+    parts = b""
+    for ds in datasets:
+        xml = to_xml(ds)
+        parts += (f"--{boundary}\r\nContent-Type: {CONTENT_TYPE_XML}\r\n\r\n").encode() + xml + b"\r\n"
+    parts += f"--{boundary}--".encode()
+    return parts
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_session_xml() -> MockSession:
+    """Provide a fresh MockSession for XML tests."""
+    return MockSession()
+
+
+@pytest.fixture
+def mock_ups_rs_xml_client(mock_session_xml: object) -> UPSRSClient:
+    """Provide a UPS-RS client configured for XML content type."""
+    with patch("requests.Session", return_value=mock_session_xml):
+        client = UPSRSClient(
+            base_url="http://example.com/dicom-web",
+            aetitle="TEST_AE",
+            timeout=30,
+            max_retries=0,  # No retries in tests
+            retry_delay=0,
+            content_type=CONTENT_TYPE_XML,
+        )
+        client.session = mock_session_xml  # type: ignore[assignment]
+        return client
+
+
+@pytest.fixture
+def xml_response_factory() -> Callable[..., XmlMockResponse]:
+    """Create mock XML responses."""
+
+    def _create(
+        status_code: int = 200,
+        xml_bytes: bytes = b"",
+        content_type: str = CONTENT_TYPE_XML,
+        extra_headers: dict[str, str] | None = None,
+    ) -> XmlMockResponse:
+        return XmlMockResponse(
+            status_code=status_code,
+            xml_bytes=xml_bytes,
+            content_type=content_type,
+            extra_headers=extra_headers,
+        )
+
+    return _create
+
+
+@pytest.fixture
+def multipart_xml_response_factory() -> Callable[..., XmlMockResponse]:
+    """Create mock multipart/related XML responses."""
+
+    def _create(datasets: list[Dataset], boundary: str = "DicomBoundary") -> XmlMockResponse:
+        body = _build_multipart_xml_body(datasets, boundary)
+        ct = f'multipart/related; type="{CONTENT_TYPE_XML}"; boundary={boundary}'
+        return XmlMockResponse(status_code=200, xml_bytes=body, content_type=ct)
+
+    return _create
+
+
+# ---------------------------------------------------------------------------
+# make_headers
+# ---------------------------------------------------------------------------
+
+
+class TestMakeHeaders:
+    """Tests for the make_headers helper."""
+
+    def test_json_content_type(self) -> None:
+        """Contract: JSON content type sets both Content-Type and Accept."""
+        headers = make_headers(CONTENT_TYPE_JSON)
+        assert headers["Content-Type"] == CONTENT_TYPE_JSON
+        assert headers["Accept"] == CONTENT_TYPE_JSON
+
+    def test_xml_content_type(self) -> None:
+        """Contract: XML content type sets both Content-Type and Accept."""
+        headers = make_headers(CONTENT_TYPE_XML)
+        assert headers["Content-Type"] == CONTENT_TYPE_XML
+        assert headers["Accept"] == CONTENT_TYPE_XML
+
+    def test_extra_headers_merged(self) -> None:
+        """Contract: extra headers are merged into the result."""
+        headers = make_headers(CONTENT_TYPE_JSON, extra={"Cache-Control": "no-cache"})
+        assert headers["Cache-Control"] == "no-cache"
+        assert headers["Content-Type"] == CONTENT_TYPE_JSON
+
+    def test_extra_headers_do_not_override_content_type(self) -> None:
+        """Contract: extra dict cannot override Content-Type (last-write wins)."""
+        # The make_headers function merges extra AFTER setting the content-type
+        # keys, so extra CAN override them. This test documents current behavior.
+        headers = make_headers(CONTENT_TYPE_JSON, extra={"Content-Type": "text/plain"})
+        # extra overrides the default — document this as expected behavior
+        assert headers["Content-Type"] == "text/plain"
+
+
+# ---------------------------------------------------------------------------
+# serialize_request
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeRequest:
+    """Tests for the serialize_request helper."""
+
+    def test_json_serializes_dict(self) -> None:
+        """Contract: JSON mode encodes dict as UTF-8 JSON bytes."""
+        result = serialize_request(_SAMPLE_JSON, CONTENT_TYPE_JSON)
+        assert isinstance(result, bytes)
+        parsed = json.loads(result)
+        assert parsed == _SAMPLE_JSON
+
+    def test_xml_serializes_dict_to_xml_bytes(self) -> None:
+        """Contract: XML mode converts dict to DICOM NativeDicomModel XML bytes."""
+        result = serialize_request(_SAMPLE_JSON, CONTENT_TYPE_XML)
+        assert isinstance(result, bytes)
+        assert b"NativeDicomModel" in result
+        # Round-trip: parse back to Dataset and verify
+        ds = from_xml(result)
+        assert "ProcedureStepState" in ds
+        assert ds.ProcedureStepState == "SCHEDULED"
+
+    def test_xml_accepts_dataset_directly(self) -> None:
+        """Contract: XML mode accepts a pydicom Dataset directly."""
+        ds = _sample_dataset()
+        result = serialize_request(ds, CONTENT_TYPE_XML)
+        assert isinstance(result, bytes)
+        assert b"NativeDicomModel" in result
+
+    def test_xml_serializes_empty_dict(self) -> None:
+        """Contract: XML mode serializes empty dict to valid (empty) XML."""
+        result = serialize_request({}, CONTENT_TYPE_XML)
+        assert isinstance(result, bytes)
+        assert b"NativeDicomModel" in result
+
+    def test_json_serializes_empty_dict(self) -> None:
+        """Contract: JSON mode serializes empty dict to '{}' bytes."""
+        result = serialize_request({}, CONTENT_TYPE_JSON)
+        assert result == b"{}"
+
+
+# ---------------------------------------------------------------------------
+# extract_boundary
+# ---------------------------------------------------------------------------
+
+
+class TestExtractBoundary:
+    """Tests for the extract_boundary helper."""
+
+    def test_extracts_unquoted_boundary(self) -> None:
+        """Contract: extracts boundary without quotes."""
+        ct = 'multipart/related; type="application/dicom+xml"; boundary=abc123'
+        assert extract_boundary(ct) == "abc123"
+
+    def test_extracts_quoted_boundary(self) -> None:
+        """Contract: extracts boundary with surrounding quotes."""
+        ct = 'multipart/related; boundary="my--boundary"'
+        assert extract_boundary(ct) == "my--boundary"
+
+    def test_returns_none_when_no_boundary(self) -> None:
+        """Contract: returns None when boundary param is absent."""
+        ct = "multipart/related; type=application/dicom+xml"
+        assert extract_boundary(ct) is None
+
+    def test_case_insensitive(self) -> None:
+        """Contract: boundary parameter name is case-insensitive."""
+        ct = "multipart/related; BOUNDARY=xyz"
+        assert extract_boundary(ct) == "xyz"
+
+
+# ---------------------------------------------------------------------------
+# parse_response_body
+# ---------------------------------------------------------------------------
+
+
+class TestParseResponseBody:
+    """Tests for the parse_response_body dispatcher."""
+
+    def test_json_content_type_returns_dict(self) -> None:
+        """Contract: application/dicom+json returns a dict."""
+        data = {"foo": "bar"}
+        result = parse_response_body(json.dumps(data).encode(), json.dumps(data), "application/dicom+json")
+        assert result == data
+
+    def test_json_content_type_returns_list(self) -> None:
+        """Contract: application/dicom+json can return a list."""
+        data = [{"foo": "bar"}, {"baz": 42}]
+        result = parse_response_body(json.dumps(data).encode(), json.dumps(data), "application/dicom+json")
+        assert result == data
+
+    def test_xml_content_type_returns_dataset(self) -> None:
+        """Contract: application/dicom+xml returns a pydicom Dataset."""
+        xml = _sample_xml()
+        result = parse_response_body(xml, xml.decode(), "application/dicom+xml; charset=utf-8")
+        assert isinstance(result, Dataset)
+        assert result.ProcedureStepState == "SCHEDULED"
+
+    def test_multipart_xml_returns_list_of_datasets(self) -> None:
+        """Contract: multipart/related returns a list of pydicom Datasets."""
+        xml = _sample_xml()
+        boundary = "MyBoundary"
+        multipart = (
+            (f"--{boundary}\r\nContent-Type: {CONTENT_TYPE_XML}\r\n\r\n").encode() + xml + (f"\r\n--{boundary}--").encode()
+        )
+
+        ct = f'multipart/related; type="{CONTENT_TYPE_XML}"; boundary={boundary}'
+        result = parse_response_body(multipart, multipart.decode(errors="replace"), ct)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], Dataset)
+
+    def test_no_content_type_falls_back_to_json(self) -> None:
+        """Contract: empty Content-Type string falls back to JSON parsing."""
+        data = {"key": "value"}
+        result = parse_response_body(json.dumps(data).encode(), json.dumps(data), "")
+        assert result == data
+
+
+# ---------------------------------------------------------------------------
+# _parse_multipart_xml
+# ---------------------------------------------------------------------------
+
+
+class TestParseMultipartXml:
+    """Tests for the internal _parse_multipart_xml helper."""
+
+    def test_parses_single_part(self) -> None:
+        """Contract: correctly parses a single-part multipart body."""
+        xml = _sample_xml()
+        boundary = "TestBound"
+        body = (
+            (f"--{boundary}\r\nContent-Type: {CONTENT_TYPE_XML}\r\n\r\n").encode() + xml + f"\r\n--{boundary}--\r\n".encode()
+        )
+
+        result = _parse_multipart_xml(body, boundary)
+        assert len(result) == 1
+        assert isinstance(result[0], Dataset)
+
+    def test_parses_multiple_parts(self) -> None:
+        """Contract: correctly parses a multi-part multipart body."""
+        xml = _sample_xml()
+        boundary = "MultiPart"
+        part = (f"--{boundary}\r\nContent-Type: {CONTENT_TYPE_XML}\r\n\r\n").encode() + xml + b"\r\n"
+        body = part + part + f"--{boundary}--".encode()
+
+        result = _parse_multipart_xml(body, boundary)
+        assert len(result) == 2
+        assert all(isinstance(ds, Dataset) for ds in result)
+
+    def test_returns_empty_list_when_boundary_is_none(self) -> None:
+        """Contract: returns empty list when boundary is None."""
+        result = _parse_multipart_xml(b"some content", None)
+        assert result == []
+
+    def test_skips_malformed_parts(self) -> None:
+        """Contract: malformed XML parts are skipped, not raised."""
+        boundary = "SkipBad"
+        bad_part = (f"--{boundary}\r\nContent-Type: {CONTENT_TYPE_XML}\r\n\r\nNOT XML AT ALL").encode()
+        body = bad_part + f"\r\n--{boundary}--".encode()
+
+        result = _parse_multipart_xml(body, boundary)
+        assert result == []  # Bad part is skipped
+
+
+# ---------------------------------------------------------------------------
+# UPSRSClient XML mode — request headers and body
+# ---------------------------------------------------------------------------
+
+
+def _make_xml_client(mock_session: object) -> UPSRSClient:
+    """Create a UPSRSClient configured for XML content type."""
+    with patch("requests.Session", return_value=mock_session):
+        client = UPSRSClient(
+            base_url="http://example.com/dicom-web",
+            aetitle="TEST_AE",
+            content_type=CONTENT_TYPE_XML,
+        )
+        client.session = mock_session  # type: ignore[assignment]
+        return client
+
+
+class TestXmlClientCreateWorkitem:
+    """Tests for create_workitem in XML mode."""
+
+    def test_sends_xml_content_type_header(self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable) -> None:
+        """Contract: XML mode sends application/dicom+xml Content-Type."""
+        response = xml_response_factory(status_code=201, xml_bytes=_sample_xml())
+        mock_ups_rs_xml_client.session.add_response("POST", r"http://example.com/dicom-web/workitems", response)
+
+        mock_ups_rs_xml_client.create_workitem(_SAMPLE_JSON)
+
+        assert len(mock_ups_rs_xml_client.session.requests) == 1
+        req = mock_ups_rs_xml_client.session.requests[0]
+        assert req["headers"]["Content-Type"] == CONTENT_TYPE_XML
+        assert req["headers"]["Accept"] == CONTENT_TYPE_XML
+
+    def test_sends_xml_body(self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable) -> None:
+        """Contract: XML mode sends serialized XML bytes as body."""
+        response = xml_response_factory(status_code=201, xml_bytes=_sample_xml())
+        mock_ups_rs_xml_client.session.add_response("POST", r"http://example.com/dicom-web/workitems", response)
+
+        mock_ups_rs_xml_client.create_workitem(_SAMPLE_JSON)
+
+        req = mock_ups_rs_xml_client.session.requests[0]
+        # The body is sent via 'data' (bytes) not 'json' (dict)
+        assert req.get("json") is None
+        body = req.get("data", b"")
+        assert isinstance(body, bytes)
+        assert b"NativeDicomModel" in body
+
+    def test_success_response_parsed(self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable) -> None:
+        """Contract: XML response body is parsed and returned as dict."""
+        response = xml_response_factory(status_code=201, xml_bytes=_sample_xml())
+        mock_ups_rs_xml_client.session.add_response("POST", r"http://example.com/dicom-web/workitems", response)
+
+        success, result = mock_ups_rs_xml_client.create_workitem(_SAMPLE_JSON)
+
+        assert success is True
+        # Result should contain the DICOM attribute data
+        assert isinstance(result, dict)
+
+
+class TestXmlClientRetrieveWorkitem:
+    """Tests for retrieve_workitem in XML mode."""
+
+    def test_sends_xml_accept_header(self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable) -> None:
+        """Contract: XML mode sends application/dicom+xml Accept header."""
+        uid = "1.2.3.4.5"
+        response = xml_response_factory(status_code=200, xml_bytes=_sample_xml())
+        mock_ups_rs_xml_client.session.add_response("GET", rf"http://example.com/dicom-web/workitems/{uid}", response)
+
+        mock_ups_rs_xml_client.retrieve_workitem(uid)
+
+        req = mock_ups_rs_xml_client.session.requests[0]
+        assert req["headers"]["Accept"] == CONTENT_TYPE_XML
+        # GET requests should not send Content-Type
+        assert "Content-Type" not in req["headers"]
+
+    def test_xml_response_parsed_to_dict(self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable) -> None:
+        """Contract: XML response is parsed and returned as dict."""
+        uid = "1.2.3.4.5"
+        response = xml_response_factory(status_code=200, xml_bytes=_sample_xml())
+        mock_ups_rs_xml_client.session.add_response("GET", rf"http://example.com/dicom-web/workitems/{uid}", response)
+
+        success, result = mock_ups_rs_xml_client.retrieve_workitem(uid)
+
+        assert success is True
+        assert isinstance(result, dict)
+        # Should contain the DICOM tag data from the XML
+        assert "00741000" in result
+
+
+class TestXmlClientSearchWorkitems:
+    """Tests for search_workitems in XML mode."""
+
+    def test_sends_xml_accept_header(
+        self, mock_ups_rs_xml_client: UPSRSClient, multipart_xml_response_factory: Callable
+    ) -> None:
+        """Contract: XML mode sends application/dicom+xml Accept header for search."""
+        boundary = "SearchBoundary"
+        response = multipart_xml_response_factory(datasets=[_sample_dataset()], boundary=boundary)
+        mock_ups_rs_xml_client.session.add_response("GET", r"http://example.com/dicom-web/workitems\?", response)
+
+        mock_ups_rs_xml_client.search_workitems({})
+
+        req = mock_ups_rs_xml_client.session.requests[0]
+        assert req["headers"]["Accept"] == CONTENT_TYPE_XML
+        assert "Content-Type" not in req["headers"]
+
+    def test_multipart_xml_response_parsed_to_list(
+        self, mock_ups_rs_xml_client: UPSRSClient, multipart_xml_response_factory: Callable
+    ) -> None:
+        """Contract: multipart/related XML response parsed to list of dicts."""
+        boundary = "MultiSearchBound"
+        response = multipart_xml_response_factory(datasets=[_sample_dataset(), _sample_dataset()], boundary=boundary)
+        mock_ups_rs_xml_client.session.add_response("GET", r"http://example.com/dicom-web/workitems\?", response)
+
+        success, result = mock_ups_rs_xml_client.search_workitems({})
+
+        assert success is True
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+
+class TestXmlClientUpdateWorkitem:
+    """Tests for update_workitem in XML mode."""
+
+    def test_sends_xml_body(self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable) -> None:
+        """Contract: XML mode sends serialized XML bytes for update."""
+        uid = "1.2.3.4.5"
+        txn_uid = "5.6.7.8.9"
+        response = xml_response_factory(status_code=200, xml_bytes=b"")
+        response._json_data = {"status": "OK"}
+        response.text = "{}"
+        response.content = b"{}"
+        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        mock_ups_rs_xml_client.session.add_response(
+            "PUT", rf"http://example.com/dicom-web/workitems/{uid}\?transaction-uid={txn_uid}", response
+        )
+
+        update_data = {"00741204": {"vr": "LO", "Value": ["Updated"]}}
+        mock_ups_rs_xml_client.update_workitem(uid, txn_uid, update_data)
+
+        req = mock_ups_rs_xml_client.session.requests[0]
+        assert req["headers"]["Content-Type"] == CONTENT_TYPE_XML
+        body = req.get("data", b"")
+        assert isinstance(body, bytes)
+        assert b"NativeDicomModel" in body
+
+
+class TestXmlClientChangeWorkitemState:
+    """Tests for change_workitem_state in XML mode."""
+
+    def test_sends_xml_body_with_state_tag(self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable) -> None:
+        """Contract: state change payload serialized to XML with correct DICOM tag."""
+        uid = "1.2.3.4.5"
+        txn_uid = "9.8.7.6.5"
+        response = xml_response_factory(status_code=200)
+        response._json_data = {"status": "OK"}
+        response.text = "{}"
+        response.content = b"{}"
+        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        mock_ups_rs_xml_client.session.add_response("PUT", rf"http://example.com/dicom-web/workitems/{uid}/state", response)
+
+        mock_ups_rs_xml_client.change_workitem_state(uid, "COMPLETED", transaction_uid=txn_uid)
+
+        req = mock_ups_rs_xml_client.session.requests[0]
+        body = req.get("data", b"")
+        assert isinstance(body, bytes)
+        assert b"NativeDicomModel" in body
+        # Verify the state value is present in the XML
+        assert b"COMPLETED" in body
+
+
+class TestXmlClientRequestCancellation:
+    """Tests for request_cancellation in XML mode."""
+
+    def test_sends_xml_body(self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable) -> None:
+        """Contract: cancellation request serialized to XML."""
+        uid = "1.2.3.4.5"
+        response = xml_response_factory(status_code=202)
+        response._json_data = {"status": "Accepted"}
+        response.text = "{}"
+        response.content = b"{}"
+        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        mock_ups_rs_xml_client.session.add_response(
+            "POST", rf"http://example.com/dicom-web/workitems/{uid}/cancelrequest", response
+        )
+
+        mock_ups_rs_xml_client.request_cancellation(uid, reason="Testing", contact_name="Cora")
+
+        req = mock_ups_rs_xml_client.session.requests[0]
+        assert req["headers"]["Content-Type"] == CONTENT_TYPE_XML
+        body = req.get("data", b"")
+        assert isinstance(body, bytes)
+        assert b"NativeDicomModel" in body
+        assert b"Testing" in body
+
+
+# ---------------------------------------------------------------------------
+# Default JSON client still works (regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestJsonClientUnchanged:
+    """Regression guard: default JSON client uses JSON everywhere."""
+
+    def test_create_workitem_json_mode(
+        self, mock_ups_rs_client: UPSRSClient, sample_workitem: dict, response_factory: Callable
+    ) -> None:
+        """Contract: default JSON client sends json=dict, not data=bytes."""
+        response = response_factory(
+            status_code=201, json_data={"status": "Success"}, headers={"Content-Location": "/workitems/1.2.3"}
+        )
+        mock_ups_rs_client.session.add_response("POST", r"http://example.com/dicom-web/workitems", response)
+
+        success, result = mock_ups_rs_client.create_workitem(sample_workitem)
+
+        assert success is True
+        req = mock_ups_rs_client.session.requests[0]
+        assert req["headers"]["Content-Type"] == CONTENT_TYPE_JSON
+        assert req.get("json") == sample_workitem
+        assert req.get("data") is None
+
+
+# ---------------------------------------------------------------------------
+# Error response always parsed as JSON
+# ---------------------------------------------------------------------------
+
+
+class TestErrorResponseParsing:
+    """Tests that error responses use JSON parsing regardless of content type."""
+
+    def test_xml_client_parses_json_error_response(
+        self, mock_ups_rs_xml_client: UPSRSClient, response_factory: Callable
+    ) -> None:
+        """Contract: error bodies are parsed as JSON even in XML mode."""
+        from tests.conftest import MockResponse
+
+        error_resp = MockResponse(
+            status_code=400,
+            json_data={"error": "Bad request"},
+            headers={"Content-Type": "application/json"},
+        )
+        mock_ups_rs_xml_client.session.add_response("POST", r"http://example.com/dicom-web/workitems", error_resp)
+
+        success, result = mock_ups_rs_xml_client.create_workitem(_SAMPLE_JSON)
+
+        assert success is False
+        assert isinstance(result, str)
+        assert "400" in result
+
+
+# ---------------------------------------------------------------------------
+# Content type stored on client
+# ---------------------------------------------------------------------------
+
+
+class TestContentTypeConfiguration:
+    """Tests for content_type parameter on UPSRSClient."""
+
+    def test_default_content_type_is_json(self) -> None:
+        """Contract: default content_type is application/dicom+json."""
+        with patch("requests.Session"):
+            client = UPSRSClient(base_url="http://example.com")
+            assert client.content_type == CONTENT_TYPE_JSON
+
+    def test_xml_content_type_stored(self) -> None:
+        """Contract: XML content_type is stored correctly."""
+        with patch("requests.Session"):
+            client = UPSRSClient(base_url="http://example.com", content_type=CONTENT_TYPE_XML)
+            assert client.content_type == CONTENT_TYPE_XML
+
+    def test_make_headers_uses_stored_content_type(self) -> None:
+        """Contract: _make_headers uses self.content_type."""
+        with patch("requests.Session"):
+            client = UPSRSClient(base_url="http://example.com", content_type=CONTENT_TYPE_XML)
+            headers = client._make_headers()
+            assert headers["Content-Type"] == CONTENT_TYPE_XML
+            assert headers["Accept"] == CONTENT_TYPE_XML

--- a/uv.lock
+++ b/uv.lock
@@ -138,6 +138,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydicom" },
+    { name = "pydicom-xml" },
     { name = "requests" },
     { name = "websockets" },
 ]
@@ -155,6 +156,7 @@ dev = [
 dev = [
     { name = "pre-commit" },
     { name = "pytest-asyncio" },
+    { name = "pytest-json-report" },
     { name = "ruff" },
     { name = "setuptools" },
 ]
@@ -162,6 +164,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pydicom", specifier = ">=3.0.1,<4.0" },
+    { name = "pydicom-xml", git = "https://github.com/sjswerdloff/pydicom-xml?rev=06032da" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0,<9.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1,<7.0" },
     { name = "requests", specifier = ">=2.32.3,<3.0" },
@@ -176,6 +179,7 @@ provides-extras = ["dev"]
 dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0" },
     { name = "ruff", specifier = ">=0.11.6" },
     { name = "setuptools", specifier = ">=80.3.1" },
 ]
@@ -279,11 +283,19 @@ wheels = [
 
 [[package]]
 name = "pydicom"
-version = "3.0.1"
+version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/6f/55ea163b344c91df2e03c007bebf94781f0817656e2c037d7c5bf86c3bfc/pydicom-3.0.1.tar.gz", hash = "sha256:7b8be344b5b62493c9452ba6f5a299f78f8a6ab79786c729b0613698209603ec", size = 2884731 }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/de/52aaf905f1f0ae7aba85996e2592ea2c1fe49157f3cfbcd1871965bdb51d/pydicom-3.0.2.tar.gz", hash = "sha256:5942bfc2d72c6fa4b3b5b62c527f54b7f2355f21d6f5d296df6bb30188df6a4f", size = 2886792 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/a6/98651e752a49f341aa99aa3f6c8ba361728dfc064242884355419df63669/pydicom-3.0.1-py3-none-any.whl", hash = "sha256:db32f78b2641bd7972096b8289111ddab01fb221610de8d7afa835eb938adb41", size = 2376126 },
+    { url = "https://files.pythonhosted.org/packages/46/e0/60466c6d712dad2cf807df315e39863e91609ffd1064ecb835994460bbda/pydicom-3.0.2-py3-none-any.whl", hash = "sha256:abf971a5440f84dbaf42c4b6758e30e62480902584f8b270b9a5d146e278a07b", size = 2376822 },
+]
+
+[[package]]
+name = "pydicom-xml"
+version = "0.1.0"
+source = { git = "https://github.com/sjswerdloff/pydicom-xml?rev=06032da#06032da7b7ef146fdd54a4dcac0f32bd417cac82" }
+dependencies = [
+    { name = "pydicom" },
 ]
 
 [[package]]
@@ -324,6 +336,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/69/5f1e57f6c5a39f81411b550027bf72842c4567ff5fd572bed1edc9e4b5d9/pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a", size = 66857 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/d0/def53b4a790cfb21483016430ed828f64830dd981ebe1089971cd10cab25/pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde", size = 23841 },
+]
+
+[[package]]
+name = "pytest-json-report"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "pytest-metadata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/d3/765dae9712fcd68d820338908c1337e077d5fdadccd5cacf95b9b0bea278/pytest-json-report-1.5.0.tar.gz", hash = "sha256:2dde3c647851a19b5f3700729e8310a6e66efb2077d674f27ddea3d34dc615de", size = 21241 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/35/d07400c715bf8a88aa0c1ee9c9eb6050ca7fe5b39981f0eea773feeb0681/pytest_json_report-1.5.0-py3-none-any.whl", hash = "sha256:9897b68c910b12a2e48dd849f9a284b2c79a732a8a9cb398452ddd23d3c8c325", size = 13222 },
+]
+
+[[package]]
+name = "pytest-metadata"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/85/8c969f8bec4e559f8f2b958a15229a35495f5b4ce499f6b865eac54b878d/pytest_metadata-3.1.1.tar.gz", hash = "sha256:d2a29b0355fbc03f168aa96d41ff88b1a3b44a3b02acbe491801c98a048017c8", size = 9952 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl", hash = "sha256:c8e0844db684ee1c798cfa38908d20d67d0463ecb6137c72e91f418558dd5f4b", size = 11428 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `application/dicom+xml` content negotiation to all UPSRSClient operations
- `content_type` parameter on constructor, `--content-type` CLI flag
- Request serialization via pydicom-xml, response parsing including multipart/related for search results
- WebSocket notifications remain JSON-only per PS3.18 Section 8.10.5
- Module split: exceptions, enums, serialization extracted to separate files
- Public API unchanged — all re-exported from `__init__.py`

## Test plan
- [x] 148 tests pass (111 existing + 37 new XML tests)
- [x] Linting clean
- [ ] Sourcery-ai review

Co-Authored-By: Cora <cora-2f1e43dc@sjstargetedsolutions.co.nz>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add XML (application/dicom+xml) content-type support to the UPS-RS client while keeping JSON as default, and split shared concerns into dedicated modules.

New Features:
- Introduce configurable content negotiation for UPS-RSClient, including constructor content_type parameter and CLI --content-type flag supporting JSON and XML.
- Add XML request/response handling, including multipart/related parsing for search results, using pydicom-xml.

Enhancements:
- Refactor client code by extracting enums, exceptions, and serialization logic into separate modules and re-exporting them from the package init for backward compatibility.
- Clean up UPSRSClient internals for header construction, response parsing, and WebSocket handling, and delegate CLI logic to a new cli module keeping legacy entry points as thin wrappers.

Build:
- Add pydicom-xml dependency and configure uv to source it from a specific Git revision, and extend dev dependencies with pytest-json-report for richer test output.

Tests:
- Add an extensive XML-focused test suite covering serialization, multipart parsing, header construction, UPSRSClient XML mode behavior, and error-handling paths.