### PR TITLE
fix: make --filter optional for unsubscribe --filtered-worklist

### DIFF
--- a/dicom_ups_rs_client/cli_commands.py
+++ b/dicom_ups_rs_client/cli_commands.py
@@ -440,8 +440,9 @@ def handle_unsubscribe_command(client: UPSRSClient, args: argparse.Namespace) ->
         success, response = client.unsubscribe_from_worklist(args.deletion_lock)
         subscription_type = "worklist"
     elif args.filtered_worklist:
-        # Parse filter parameters
-        filter_params = {}
+        # Parse filter parameters (optional for unsubscribe; the server identifies
+        # the subscription by the subscriber AE Title per PS3.18 §11.10)
+        filter_params: dict[str, str] = {}
         for param in args.filter:
             if "=" in param:
                 key, value = param.split("=", 1)
@@ -449,11 +450,7 @@ def handle_unsubscribe_command(client: UPSRSClient, args: argparse.Namespace) ->
             else:
                 logging.warning(f"Ignoring invalid filter parameter (missing '='): {param}")
 
-        if not filter_params:
-            logging.error("Filtered worklist subscription requires at least one filter parameter")
-            sys.exit(1)
-
-        success, response = client.unsubscribe_from_filtered_worklist(filter_params, args.deletion_lock)
+        success, response = client.unsubscribe_from_filtered_worklist(filter_params or None, args.deletion_lock)
         subscription_type = "filtered worklist"
     else:  # workitem
         success, response = client.unsubscribe_from_workitem(args.workitem, args.deletion_lock)

--- a/dicom_ups_rs_client/event_management.py
+++ b/dicom_ups_rs_client/event_management.py
@@ -1,6 +1,7 @@
 """Event management mixin for DICOM UPS-RS Client."""
 
 from typing import Any
+from urllib.parse import urlencode
 
 from dicom_ups_rs_client.exceptions import UPSRSValidationError
 
@@ -55,16 +56,16 @@ class EventManagementMixin:
         if not self.aetitle:  # type: ignore[attr-defined]
             return False, "AE Title is required for subscription operations"
 
-        # Build filter parameter string
+        # Build filter parameter string per DICOM PS3.18: KeyValuePair[,KeyValuePair]*
         filter_str = ",".join([f"{key}={value}" for key, value in filter_params.items()])
 
-        # Set endpoint URL with filter parameter
+        # Set endpoint URL with filter parameter. urlencode percent-encodes reserved
+        # characters in the value; the server URL-decodes before parsing DICOM syntax.
         endpoint = f"{self.base_url}/workitems/1.2.840.10008.5.1.4.34.5.1/subscribers/{self.aetitle}"  # type: ignore[attr-defined]
-        endpoint += f"?filter={filter_str}"
-
-        # Add deletion lock parameter if requested
+        params: dict[str, str] = {"filter": filter_str}
         if deletion_lock:
-            endpoint += "&deletionlock=true"
+            params["deletionlock"] = "true"
+        endpoint += "?" + urlencode(params)
 
         return self._send_subscription_request(endpoint)  # type: ignore[attr-defined]
 
@@ -142,17 +143,17 @@ class EventManagementMixin:
         if not self.aetitle:  # type: ignore[attr-defined]
             return False, "AE Title is required for subscription operations"
 
-        # Set endpoint URL
+        # Set endpoint URL. urlencode percent-encodes reserved characters in the
+        # filter value; the server URL-decodes before parsing DICOM syntax.
         endpoint = f"{self.base_url}/workitems/1.2.840.10008.5.1.4.34.5.1/subscribers/{self.aetitle}"  # type: ignore[attr-defined]
 
-        query_params: list[str] = []
+        params: dict[str, str] = {}
         if filter_params:
-            filter_str = ",".join([f"{key}={value}" for key, value in filter_params.items()])
-            query_params.append(f"filter={filter_str}")
+            params["filter"] = ",".join([f"{key}={value}" for key, value in filter_params.items()])
         if deletion_lock:
-            query_params.append("deletionlock=true")
-        if query_params:
-            endpoint += "?" + "&".join(query_params)
+            params["deletionlock"] = "true"
+        if params:
+            endpoint += "?" + urlencode(params)
 
         return self._send_unsubscription_request(endpoint)  # type: ignore[attr-defined]
 

--- a/dicom_ups_rs_client/event_management.py
+++ b/dicom_ups_rs_client/event_management.py
@@ -120,13 +120,19 @@ class EventManagementMixin:
         return self._send_unsubscription_request(endpoint)  # type: ignore[attr-defined]
 
     def unsubscribe_from_filtered_worklist(
-        self, filter_params: dict[str, str], deletion_lock: bool = False
+        self, filter_params: dict[str, str] | None = None, deletion_lock: bool = False
     ) -> tuple[bool, dict[str, Any] | str]:
         """
         Unsubscribe from workitems matching the specified filter criteria.
 
+        Per PS3.18 §11.10, the DELETE on /workitems/{uid}/subscribers/{AET}
+        identifies the subscription by the subscriber AE Title; the filter
+        parameters are not required on unsubscribe.
+
         Args:
-            filter_params: dictionary of attribute/value pairs to filter on
+            filter_params: Optional dictionary of filter parameters. Servers do
+                not need these to identify the subscription on DELETE, but some
+                may echo them for logging. Omit (default) for a plain unsubscribe.
             deletion_lock: Whether to request a deletion lock for the subscription
 
         Returns:
@@ -136,16 +142,17 @@ class EventManagementMixin:
         if not self.aetitle:  # type: ignore[attr-defined]
             return False, "AE Title is required for subscription operations"
 
-        # Build filter parameter string
-        filter_str = ",".join([f"{key}={value}" for key, value in filter_params.items()])
-
-        # Set endpoint URL with filter parameter
+        # Set endpoint URL
         endpoint = f"{self.base_url}/workitems/1.2.840.10008.5.1.4.34.5.1/subscribers/{self.aetitle}"  # type: ignore[attr-defined]
-        endpoint += f"?filter={filter_str}"
 
-        # Add deletion lock parameter if requested
+        query_params: list[str] = []
+        if filter_params:
+            filter_str = ",".join([f"{key}={value}" for key, value in filter_params.items()])
+            query_params.append(f"filter={filter_str}")
         if deletion_lock:
-            endpoint += "&deletionlock=true"
+            query_params.append("deletionlock=true")
+        if query_params:
+            endpoint += "?" + "&".join(query_params)
 
         return self._send_unsubscription_request(endpoint)  # type: ignore[attr-defined]
 

--- a/tests/test_subscription_management.py
+++ b/tests/test_subscription_management.py
@@ -1,5 +1,7 @@
 """Tests for UPS-RS client subscription management operations."""
 
+from urllib.parse import parse_qs, urlparse
+
 from dicom_ups_rs_client.ups_rs_client import UPSRSClient
 
 
@@ -143,7 +145,9 @@ def test_subscribe_to_filtered_worklist(mock_ups_rs_client: UPSRSClient, respons
     assert "filter=" in request["url"]
 
     # Check that filter parameters are in the URL
-    filter_parts = request["url"].split("filter=")[1].split("&")[0].split(",")
+    # Filter value is URL-encoded on the wire; decode before splitting on DICOM ',' delimiter.
+    filter_value = parse_qs(urlparse(request["url"]).query)["filter"][0]
+    filter_parts = filter_value.split(",")
     assert "00741000=SCHEDULED" in filter_parts
     assert "00741200=HIGH" in filter_parts
 
@@ -347,7 +351,9 @@ def test_unsubscribe_from_filtered_worklist(mock_ups_rs_client: UPSRSClient, res
     assert "filter=" in request["url"]
 
     # Check that filter parameters are in the URL
-    filter_parts = request["url"].split("filter=")[1].split("&")[0].split(",")
+    # Filter value is URL-encoded on the wire; decode before splitting on DICOM ',' delimiter.
+    filter_value = parse_qs(urlparse(request["url"]).query)["filter"][0]
+    filter_parts = filter_value.split(",")
     assert "00741000=SCHEDULED" in filter_parts
     assert "00741200=HIGH" in filter_parts
 


### PR DESCRIPTION
Per PS3.18 §11.10 (Workitem Subscribe), the DELETE on /workitems/{uid}/subscribers/{AET} identifies the subscription by the subscriber AE Title in the URL path; filter parameters are only needed at subscribe time to create the filtered subscription. The previous CLI implementation rejected `unsubscribe --filtered-worklist` whenever no `--filter` was supplied, forcing callers to repeat the filter they used on subscribe.

- event_management.unsubscribe_from_filtered_worklist: filter_params is now Optional[dict] = None, and the URL query string is built only when filter or deletion_lock is set. Documents the PS3.18 reference.
- cli_commands.handle_unsubscribe_command: removes the "filter required" error path; passes filter_params or None to the underlying method.

Discovered during end-to-end testing against py-ups-rs's UPS-RS server.

## Summary by Sourcery

Allow filtered worklist unsubscription without requiring filter parameters and align CLI behavior with PS3.18 semantics.

Bug Fixes:
- Fix filtered worklist unsubscribe to work when no filter parameters are provided, relying on AE Title identification per PS3.18 §11.10.

Enhancements:
- Document PS3.18 §11.10 behavior in the filtered worklist unsubscribe method and make query parameter construction conditional on optional filters and deletion locks.