### PR TITLE
test: XML round-trip regression coverage for PS3.18 wire forms

### DIFF
--- a/tests/test_ssl_functionality.py
+++ b/tests/test_ssl_functionality.py
@@ -11,6 +11,22 @@ import pytest
 from dicom_ups_rs_client.ups_rs_client import UPSRSClient
 
 
+def _hang_future() -> asyncio.Future:
+    """
+    Create a never-completing Future for use as an AsyncMock side_effect sentinel.
+
+    Python 3.14 removed the implicit thread-default event loop, so ``asyncio.Future()``
+    called from synchronous code now raises ``RuntimeError: There is no current event
+    loop``. Provide one explicitly so this works on 3.10 through 3.14+.
+    """
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop.create_future()
+
+
 @pytest.fixture
 def ssl_client() -> Generator[UPSRSClient, None, None]:
     """Fixture that provides a UPS-RS client with common setup and guaranteed cleanup."""
@@ -63,7 +79,7 @@ def test_ssl_websocket_connection_with_disabled_verification() -> None:
             mock_connect.return_value = mock_websocket
 
             # Make recv() return a valid JSON string once and then never complete
-            future = asyncio.Future()
+            future = _hang_future()
             mock_websocket.__aenter__.return_value.recv = AsyncMock(
                 side_effect=["{}"] + [future] * 10  # First return valid JSON, then hang
             )
@@ -123,7 +139,7 @@ def test_ssl_websocket_connection_with_custom_ca_bundle() -> None:
                 # Create a proper mock for the websocket
                 mock_websocket = AsyncMock()
                 # Return a valid JSON string once, then futures that never complete
-                future = asyncio.Future()
+                future = _hang_future()
                 mock_websocket.__aenter__.return_value.recv = AsyncMock(side_effect=["{}"] + [future] * 10)
                 mock_connect.return_value = mock_websocket
 
@@ -175,7 +191,7 @@ def test_ssl_websocket_connection_with_client_cert() -> None:
                 # Create a proper mock for the websocket
                 mock_websocket = AsyncMock()
                 # Return a valid JSON string once, then futures that never complete
-                future = asyncio.Future()
+                future = _hang_future()
                 mock_websocket.__aenter__.return_value.recv = AsyncMock(side_effect=["{}"] + [future] * 10)
                 mock_connect.return_value = mock_websocket
 
@@ -223,7 +239,7 @@ def test_non_ssl_websocket_connection() -> None:
             # Create a proper mock for the websocket
             mock_websocket = AsyncMock()
             # Return a valid JSON string once, then futures that never complete
-            future = asyncio.Future()
+            future = _hang_future()
             mock_websocket.__aenter__.return_value.recv = AsyncMock(side_effect=["{}"] + [future] * 10)
             mock_connect.return_value = mock_websocket
 
@@ -288,7 +304,7 @@ async def test_ssl_context_configuration() -> None:
                 # Create a mock for the websocket that returns a valid JSON string once
                 mock_websocket = AsyncMock()
                 # Return a valid JSON string once, then futures that never complete
-                future = asyncio.Future()
+                future = _hang_future()
                 mock_websocket.__aenter__.return_value.recv = AsyncMock(side_effect=["{}"] + [future] * 10)
                 mock_connect.return_value = mock_websocket
 

--- a/tests/test_ssl_functionality.py
+++ b/tests/test_ssl_functionality.py
@@ -18,6 +18,12 @@ def _hang_future() -> asyncio.Future:
     Python 3.14 removed the implicit thread-default event loop, so ``asyncio.Future()``
     called from synchronous code now raises ``RuntimeError: There is no current event
     loop``. Provide one explicitly so this works on 3.10 through 3.14+.
+
+    Note: this sets the loop as the thread default. Sourcery flagged that as global
+    state mutation; a non-mutating variant attaching the future to a module-private
+    loop was tried and broke the tests (the future has to share a loop with the code
+    that awaits it inside the websocket handler thread). The mutation is contained
+    to this test module and accepted as the cost of the test design.
     """
     try:
         loop = asyncio.get_event_loop()

--- a/tests/test_xml_support.py
+++ b/tests/test_xml_support.py
@@ -654,3 +654,272 @@ class TestContentTypeConfiguration:
             headers = client._make_headers()
             assert headers["Content-Type"] == CONTENT_TYPE_XML
             assert headers["Accept"] == CONTENT_TYPE_XML
+
+
+# ---------------------------------------------------------------------------
+# XML round-trip regression coverage for PS3.18 wire-form correctness
+# ---------------------------------------------------------------------------
+
+
+class TestXmlClientUpdateUrlShape:
+    """Contracts for the URL form used by update_workitem in XML mode."""
+
+    def test_transaction_uid_is_query_param_with_canonical_case(
+        self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable
+    ) -> None:
+        """PS3.18 §11.6.1: Transaction UID is the 'Transaction-uid' query parameter."""
+        uid = "1.2.3.4.5"
+        txn_uid = "5.6.7.8.9"
+        response = xml_response_factory(status_code=200)
+        response._json_data = {"status": "OK"}
+        response.text = "{}"
+        response.content = b"{}"
+        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        mock_ups_rs_xml_client.session.add_response(
+            "POST", rf"http://example.com/dicom-web/workitems/{uid}\?Transaction-uid={txn_uid}", response
+        )
+
+        mock_ups_rs_xml_client.update_workitem(uid, txn_uid, {"00741204": {"vr": "LO", "Value": ["x"]}})
+
+        req = mock_ups_rs_xml_client.session.requests[0]
+        assert req["method"] == "POST"
+        assert f"?Transaction-uid={txn_uid}" in req["url"]
+        # Standard flavor: txn UID is in the URL, not the body
+        assert b"00081195" not in req.get("data", b"")
+
+
+class TestXmlClientChangeStateAllStates:
+    """Cover IN PROGRESS / COMPLETED / CANCELED state transitions in XML mode."""
+
+    @pytest.mark.parametrize("state", ["IN PROGRESS", "COMPLETED", "CANCELED"])
+    def test_state_value_serialized_in_xml_body(
+        self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable, state: str
+    ) -> None:
+        """Each terminal state lands in the XML body as a CS attribute with Transaction UID."""
+        uid = "1.2.3.4.5"
+        txn_uid = "9.8.7.6.5"
+        response = xml_response_factory(status_code=200)
+        response._json_data = {"status": "OK"}
+        response.text = "{}"
+        response.content = b"{}"
+        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        mock_ups_rs_xml_client.session.add_response("PUT", rf"http://example.com/dicom-web/workitems/{uid}/state", response)
+
+        mock_ups_rs_xml_client.change_workitem_state(uid, state, transaction_uid=txn_uid)
+
+        req = mock_ups_rs_xml_client.session.requests[0]
+        body = req.get("data", b"")
+        assert isinstance(body, bytes)
+        assert b"NativeDicomModel" in body
+        assert state.encode() in body
+        # Transaction UID (0008,1195) must accompany every state change
+        assert b"00081195" in body or txn_uid.encode() in body
+
+    def test_requester_aetitle_in_url_query(self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable) -> None:
+        """PS3.18 §11.7.1: requester AE Title is the 'requester' query parameter (standard flavor)."""
+        uid = "1.2.3.4.5"
+        txn_uid = "9.8.7.6.5"
+        response = xml_response_factory(status_code=200)
+        response._json_data = {"status": "OK"}
+        response.text = "{}"
+        response.content = b"{}"
+        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        mock_ups_rs_xml_client.session.add_response("PUT", rf"http://example.com/dicom-web/workitems/{uid}/state", response)
+
+        mock_ups_rs_xml_client.change_workitem_state(uid, "IN PROGRESS", transaction_uid=txn_uid)
+
+        req = mock_ups_rs_xml_client.session.requests[0]
+        assert "?requester=TEST_AE" in req["url"]
+
+
+class TestXmlClientRequestCancellationUrlShape:
+    """URL-shape contract for request_cancellation in XML mode (PS3.18 §11.8)."""
+
+    def test_requester_aetitle_in_url_query(self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable) -> None:
+        """PS3.18 §11.8: requester AE Title is the 'requester' query parameter (standard flavor)."""
+        uid = "1.2.3.4.5"
+        response = xml_response_factory(status_code=202)
+        response._json_data = {"status": "Accepted"}
+        response.text = "{}"
+        response.content = b"{}"
+        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        mock_ups_rs_xml_client.session.add_response(
+            "POST", rf"http://example.com/dicom-web/workitems/{uid}/cancelrequest", response
+        )
+
+        mock_ups_rs_xml_client.request_cancellation(uid, reason="end-to-end")
+
+        req = mock_ups_rs_xml_client.session.requests[0]
+        assert "?requester=TEST_AE" in req["url"]
+
+
+class TestXmlClientSubscriptions:
+    """Subscribe / unsubscribe URL contracts in XML mode."""
+
+    def test_subscribe_to_worklist_url(self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable) -> None:
+        """Global worklist subscribe POSTs to the well-known UID with the subscriber AET in the path."""
+        response = xml_response_factory(status_code=201)
+        response._json_data = {}
+        response.text = "{}"
+        response.content = b"{}"
+        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        mock_ups_rs_xml_client.session.add_response(
+            "POST", r"http://example.com/dicom-web/workitems/1.2.840.10008.5.1.4.34.5/subscribers/TEST_AE", response
+        )
+
+        mock_ups_rs_xml_client.subscribe_to_worklist()
+
+        req = mock_ups_rs_xml_client.session.requests[0]
+        assert req["method"] == "POST"
+        assert req["url"].endswith("/workitems/1.2.840.10008.5.1.4.34.5/subscribers/TEST_AE")
+
+    def test_subscribe_to_filtered_worklist_encodes_filter(
+        self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable
+    ) -> None:
+        """Filtered worklist subscribe includes filter as URL-encoded query parameter."""
+        response = xml_response_factory(status_code=201)
+        response._json_data = {}
+        response.text = "{}"
+        response.content = b"{}"
+        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        mock_ups_rs_xml_client.session.add_response(
+            "POST",
+            r"http://example.com/dicom-web/workitems/1.2.840.10008.5.1.4.34.5.1/subscribers/TEST_AE.*",
+            response,
+        )
+
+        mock_ups_rs_xml_client.subscribe_to_filtered_worklist({"00741000": "SCHEDULED"})
+
+        req = mock_ups_rs_xml_client.session.requests[0]
+        # urlencode percent-encodes the '=' inside the DICOM filter syntax
+        from urllib.parse import parse_qs, urlparse
+
+        filter_value = parse_qs(urlparse(req["url"]).query)["filter"][0]
+        assert filter_value == "00741000=SCHEDULED"
+
+    def test_unsubscribe_from_worklist_uses_delete(
+        self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable
+    ) -> None:
+        """Unsubscribe is HTTP DELETE on the subscriber resource."""
+        response = xml_response_factory(status_code=200)
+        response._json_data = {}
+        response.text = "{}"
+        response.content = b"{}"
+        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        mock_ups_rs_xml_client.session.add_response(
+            "DELETE", r"http://example.com/dicom-web/workitems/1.2.840.10008.5.1.4.34.5/subscribers/TEST_AE", response
+        )
+
+        mock_ups_rs_xml_client.unsubscribe_from_worklist()
+
+        req = mock_ups_rs_xml_client.session.requests[0]
+        assert req["method"] == "DELETE"
+
+    def test_subscribe_to_specific_workitem_url(
+        self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable
+    ) -> None:
+        """Per-workitem subscribe POSTs to /workitems/{UID}/subscribers/{AET}."""
+        uid = "1.2.3.4.5"
+        response = xml_response_factory(status_code=201)
+        response._json_data = {}
+        response.text = "{}"
+        response.content = b"{}"
+        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        mock_ups_rs_xml_client.session.add_response(
+            "POST", rf"http://example.com/dicom-web/workitems/{uid}/subscribers/TEST_AE", response
+        )
+
+        mock_ups_rs_xml_client.subscribe_to_workitem(uid)
+
+        req = mock_ups_rs_xml_client.session.requests[0]
+        assert req["url"].endswith(f"/workitems/{uid}/subscribers/TEST_AE")
+
+
+# ---------------------------------------------------------------------------
+# dcm4chee-flavor URL/body shape regression (server_flavor="dcm4chee")
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_ups_rs_xml_dcm4chee_client(mock_session_xml: object) -> UPSRSClient:
+    """XML client configured for dcm4chee's non-conformant URL convention."""
+    with patch("requests.Session", return_value=mock_session_xml):
+        client = UPSRSClient(
+            base_url="http://example.com/dicom-web",
+            aetitle="TEST_AE",
+            timeout=30,
+            max_retries=0,
+            retry_delay=0,
+            content_type=CONTENT_TYPE_XML,
+            server_flavor="dcm4chee",
+        )
+        client.session = mock_session_xml  # type: ignore[assignment]
+        return client
+
+
+class TestXmlClientDcm4cheeFlavor:
+    """dcm4chee flavor: requester as path segment, Transaction UID in body for update."""
+
+    def test_update_puts_transaction_uid_in_body_not_url(
+        self, mock_ups_rs_xml_dcm4chee_client: UPSRSClient, xml_response_factory: Callable
+    ) -> None:
+        """dcm4chee-flavor update places Transaction UID (0008,1195) in the body, not the URL."""
+        uid = "1.2.3.4.5"
+        txn_uid = "5.6.7.8.9"
+        response = xml_response_factory(status_code=200)
+        response._json_data = {"status": "OK"}
+        response.text = "{}"
+        response.content = b"{}"
+        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        mock_ups_rs_xml_dcm4chee_client.session.add_response(
+            "POST", rf"http://example.com/dicom-web/workitems/{uid}$", response
+        )
+
+        mock_ups_rs_xml_dcm4chee_client.update_workitem(uid, txn_uid, {"00741204": {"vr": "LO", "Value": ["x"]}})
+
+        req = mock_ups_rs_xml_dcm4chee_client.session.requests[0]
+        assert "Transaction-uid" not in req["url"]
+        # Transaction UID tag must be in the serialized XML body
+        body = req.get("data", b"")
+        assert b"00081195" in body or txn_uid.encode() in body
+
+    def test_change_state_puts_requester_in_path(
+        self, mock_ups_rs_xml_dcm4chee_client: UPSRSClient, xml_response_factory: Callable
+    ) -> None:
+        """dcm4chee-flavor state change uses /state/{AET} path segment, not ?requester=."""
+        uid = "1.2.3.4.5"
+        txn_uid = "9.8.7.6.5"
+        response = xml_response_factory(status_code=200)
+        response._json_data = {"status": "OK"}
+        response.text = "{}"
+        response.content = b"{}"
+        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        mock_ups_rs_xml_dcm4chee_client.session.add_response(
+            "PUT", rf"http://example.com/dicom-web/workitems/{uid}/state/TEST_AE", response
+        )
+
+        mock_ups_rs_xml_dcm4chee_client.change_workitem_state(uid, "IN PROGRESS", transaction_uid=txn_uid)
+
+        req = mock_ups_rs_xml_dcm4chee_client.session.requests[0]
+        assert req["url"].endswith("/state/TEST_AE")
+        assert "?requester=" not in req["url"]
+
+    def test_cancelrequest_puts_requester_in_path(
+        self, mock_ups_rs_xml_dcm4chee_client: UPSRSClient, xml_response_factory: Callable
+    ) -> None:
+        """dcm4chee-flavor cancelrequest uses /cancelrequest/{AET} path segment."""
+        uid = "1.2.3.4.5"
+        response = xml_response_factory(status_code=202)
+        response._json_data = {"status": "Accepted"}
+        response.text = "{}"
+        response.content = b"{}"
+        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        mock_ups_rs_xml_dcm4chee_client.session.add_response(
+            "POST", rf"http://example.com/dicom-web/workitems/{uid}/cancelrequest/TEST_AE", response
+        )
+
+        mock_ups_rs_xml_dcm4chee_client.request_cancellation(uid, reason="x")
+
+        req = mock_ups_rs_xml_dcm4chee_client.session.requests[0]
+        assert req["url"].endswith("/cancelrequest/TEST_AE")
+        assert "?requester=" not in req["url"]

--- a/tests/test_xml_support.py
+++ b/tests/test_xml_support.py
@@ -661,6 +661,27 @@ class TestContentTypeConfiguration:
 # ---------------------------------------------------------------------------
 
 
+def _make_json_status_response(
+    factory: Callable[..., XmlMockResponse],
+    *,
+    status_code: int = 200,
+    payload: dict[str, Any] | None = None,
+) -> XmlMockResponse:
+    """
+    Build an XML-mode mock response whose body and headers indicate a JSON status payload.
+
+    Most UPS-RS write operations have an XML request body but the server returns a
+    short JSON status object. Factoring this 5-line setup keeps the tests below
+    focused on the URL-shape and body assertions that actually matter.
+    """
+    response = factory(status_code=status_code)
+    response._json_data = payload if payload is not None else {}
+    response.text = "{}"
+    response.content = b"{}"
+    response.headers["Content-Type"] = CONTENT_TYPE_JSON
+    return response
+
+
 class TestXmlClientUpdateUrlShape:
     """Contracts for the URL form used by update_workitem in XML mode."""
 
@@ -670,11 +691,7 @@ class TestXmlClientUpdateUrlShape:
         """PS3.18 §11.6.1: Transaction UID is the 'Transaction-uid' query parameter."""
         uid = "1.2.3.4.5"
         txn_uid = "5.6.7.8.9"
-        response = xml_response_factory(status_code=200)
-        response._json_data = {"status": "OK"}
-        response.text = "{}"
-        response.content = b"{}"
-        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        response = _make_json_status_response(xml_response_factory, status_code=200, payload={"status": "OK"})
         mock_ups_rs_xml_client.session.add_response(
             "POST", rf"http://example.com/dicom-web/workitems/{uid}\?Transaction-uid={txn_uid}", response
         )
@@ -698,11 +715,7 @@ class TestXmlClientChangeStateAllStates:
         """Each terminal state lands in the XML body as a CS attribute with Transaction UID."""
         uid = "1.2.3.4.5"
         txn_uid = "9.8.7.6.5"
-        response = xml_response_factory(status_code=200)
-        response._json_data = {"status": "OK"}
-        response.text = "{}"
-        response.content = b"{}"
-        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        response = _make_json_status_response(xml_response_factory, status_code=200, payload={"status": "OK"})
         mock_ups_rs_xml_client.session.add_response("PUT", rf"http://example.com/dicom-web/workitems/{uid}/state", response)
 
         mock_ups_rs_xml_client.change_workitem_state(uid, state, transaction_uid=txn_uid)
@@ -719,11 +732,7 @@ class TestXmlClientChangeStateAllStates:
         """PS3.18 §11.7.1: requester AE Title is the 'requester' query parameter (standard flavor)."""
         uid = "1.2.3.4.5"
         txn_uid = "9.8.7.6.5"
-        response = xml_response_factory(status_code=200)
-        response._json_data = {"status": "OK"}
-        response.text = "{}"
-        response.content = b"{}"
-        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        response = _make_json_status_response(xml_response_factory, status_code=200, payload={"status": "OK"})
         mock_ups_rs_xml_client.session.add_response("PUT", rf"http://example.com/dicom-web/workitems/{uid}/state", response)
 
         mock_ups_rs_xml_client.change_workitem_state(uid, "IN PROGRESS", transaction_uid=txn_uid)
@@ -738,11 +747,7 @@ class TestXmlClientRequestCancellationUrlShape:
     def test_requester_aetitle_in_url_query(self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable) -> None:
         """PS3.18 §11.8: requester AE Title is the 'requester' query parameter (standard flavor)."""
         uid = "1.2.3.4.5"
-        response = xml_response_factory(status_code=202)
-        response._json_data = {"status": "Accepted"}
-        response.text = "{}"
-        response.content = b"{}"
-        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        response = _make_json_status_response(xml_response_factory, status_code=202, payload={"status": "Accepted"})
         mock_ups_rs_xml_client.session.add_response(
             "POST", rf"http://example.com/dicom-web/workitems/{uid}/cancelrequest", response
         )
@@ -758,11 +763,7 @@ class TestXmlClientSubscriptions:
 
     def test_subscribe_to_worklist_url(self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable) -> None:
         """Global worklist subscribe POSTs to the well-known UID with the subscriber AET in the path."""
-        response = xml_response_factory(status_code=201)
-        response._json_data = {}
-        response.text = "{}"
-        response.content = b"{}"
-        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        response = _make_json_status_response(xml_response_factory, status_code=201, payload={})
         mock_ups_rs_xml_client.session.add_response(
             "POST", r"http://example.com/dicom-web/workitems/1.2.840.10008.5.1.4.34.5/subscribers/TEST_AE", response
         )
@@ -777,11 +778,7 @@ class TestXmlClientSubscriptions:
         self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable
     ) -> None:
         """Filtered worklist subscribe includes filter as URL-encoded query parameter."""
-        response = xml_response_factory(status_code=201)
-        response._json_data = {}
-        response.text = "{}"
-        response.content = b"{}"
-        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        response = _make_json_status_response(xml_response_factory, status_code=201, payload={})
         mock_ups_rs_xml_client.session.add_response(
             "POST",
             r"http://example.com/dicom-web/workitems/1.2.840.10008.5.1.4.34.5.1/subscribers/TEST_AE.*",
@@ -801,11 +798,7 @@ class TestXmlClientSubscriptions:
         self, mock_ups_rs_xml_client: UPSRSClient, xml_response_factory: Callable
     ) -> None:
         """Unsubscribe is HTTP DELETE on the subscriber resource."""
-        response = xml_response_factory(status_code=200)
-        response._json_data = {}
-        response.text = "{}"
-        response.content = b"{}"
-        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        response = _make_json_status_response(xml_response_factory, status_code=200, payload={})
         mock_ups_rs_xml_client.session.add_response(
             "DELETE", r"http://example.com/dicom-web/workitems/1.2.840.10008.5.1.4.34.5/subscribers/TEST_AE", response
         )
@@ -820,11 +813,7 @@ class TestXmlClientSubscriptions:
     ) -> None:
         """Per-workitem subscribe POSTs to /workitems/{UID}/subscribers/{AET}."""
         uid = "1.2.3.4.5"
-        response = xml_response_factory(status_code=201)
-        response._json_data = {}
-        response.text = "{}"
-        response.content = b"{}"
-        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        response = _make_json_status_response(xml_response_factory, status_code=201, payload={})
         mock_ups_rs_xml_client.session.add_response(
             "POST", rf"http://example.com/dicom-web/workitems/{uid}/subscribers/TEST_AE", response
         )
@@ -866,11 +855,7 @@ class TestXmlClientDcm4cheeFlavor:
         """dcm4chee-flavor update places Transaction UID (0008,1195) in the body, not the URL."""
         uid = "1.2.3.4.5"
         txn_uid = "5.6.7.8.9"
-        response = xml_response_factory(status_code=200)
-        response._json_data = {"status": "OK"}
-        response.text = "{}"
-        response.content = b"{}"
-        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        response = _make_json_status_response(xml_response_factory, status_code=200, payload={"status": "OK"})
         mock_ups_rs_xml_dcm4chee_client.session.add_response(
             "POST", rf"http://example.com/dicom-web/workitems/{uid}$", response
         )
@@ -889,11 +874,7 @@ class TestXmlClientDcm4cheeFlavor:
         """dcm4chee-flavor state change uses /state/{AET} path segment, not ?requester=."""
         uid = "1.2.3.4.5"
         txn_uid = "9.8.7.6.5"
-        response = xml_response_factory(status_code=200)
-        response._json_data = {"status": "OK"}
-        response.text = "{}"
-        response.content = b"{}"
-        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        response = _make_json_status_response(xml_response_factory, status_code=200, payload={"status": "OK"})
         mock_ups_rs_xml_dcm4chee_client.session.add_response(
             "PUT", rf"http://example.com/dicom-web/workitems/{uid}/state/TEST_AE", response
         )
@@ -909,11 +890,7 @@ class TestXmlClientDcm4cheeFlavor:
     ) -> None:
         """dcm4chee-flavor cancelrequest uses /cancelrequest/{AET} path segment."""
         uid = "1.2.3.4.5"
-        response = xml_response_factory(status_code=202)
-        response._json_data = {"status": "Accepted"}
-        response.text = "{}"
-        response.content = b"{}"
-        response.headers["Content-Type"] = CONTENT_TYPE_JSON
+        response = _make_json_status_response(xml_response_factory, status_code=202, payload={"status": "Accepted"})
         mock_ups_rs_xml_dcm4chee_client.session.add_response(
             "POST", rf"http://example.com/dicom-web/workitems/{uid}/cancelrequest/TEST_AE", response
         )


### PR DESCRIPTION
## Summary by Sourcery

Add XML-mode UPS-RS client regression tests for PS3.18 wire-form correctness and adjust SSL websocket tests for asyncio compatibility across Python versions.

Tests:
- Add XML round-trip regression tests validating URL, query parameters, and XML body contracts for UPS-RS workitem updates, state changes, cancellations, and subscriptions in both standard and dcm4chee server flavors.
- Update SSL websocket tests to use a helper that creates hang Futures with an explicit event loop for compatibility with Python 3.10–3.14+.